### PR TITLE
Vnext

### DIFF
--- a/src/Abstractions/IDefaultFilenameContainer.cs
+++ b/src/Abstractions/IDefaultFilenameContainer.cs
@@ -1,0 +1,6 @@
+﻿namespace TemplateFramework.Abstractions;
+
+public interface IDefaultFilenameContainer
+{
+    string DefaultFilename { get; set; }
+}

--- a/src/Abstractions/ITemplateEngine.cs
+++ b/src/Abstractions/ITemplateEngine.cs
@@ -3,4 +3,5 @@
 public interface ITemplateEngine
 {
     void Render(IRenderTemplateRequest request);
+    ITemplateParameter[] GetParameters(object templateInstance);
 }

--- a/src/Abstractions/ITemplateParameterExtractor.cs
+++ b/src/Abstractions/ITemplateParameterExtractor.cs
@@ -1,0 +1,6 @@
+﻿namespace TemplateFramework.Abstractions;
+
+public interface ITemplateParameterExtractor
+{
+    ITemplateParameter[] Extract(object templateInstance);
+}

--- a/src/Abstractions/ITemplateParameterExtractorComponent.cs
+++ b/src/Abstractions/ITemplateParameterExtractorComponent.cs
@@ -1,0 +1,6 @@
+﻿namespace TemplateFramework.Abstractions;
+
+public interface ITemplateParameterExtractorComponent : ITemplateParameterExtractor
+{
+    bool Supports(object templateInstance);
+}

--- a/src/Abstractions/TemplateFramework.Abstractions.csproj
+++ b/src/Abstractions/TemplateFramework.Abstractions.csproj
@@ -17,6 +17,7 @@
     <Using Include="TemplateFramework.Abstractions.CodeGeneration" />
     <Using Include="TemplateFramework.Abstractions.Domains" />
     <Using Include="TemplateFramework.Abstractions.Requests" />
+    <Using Include="TemplateFramework.Abstractions.Templates" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Console/Abstractions/IUserInput.cs
+++ b/src/Console/Abstractions/IUserInput.cs
@@ -2,5 +2,5 @@
 
 public interface IUserInput
 {
-    string GetValue(TemplateParameter parameter);
+    string GetValue(ITemplateParameter parameter);
 }

--- a/src/Console/Commands/RunTemplateCommand.cs
+++ b/src/Console/Commands/RunTemplateCommand.cs
@@ -4,14 +4,17 @@ public class RunTemplateCommand : CommandBase
 {
     private readonly ITemplateProvider _templateProvider;
     private readonly ITemplateEngine _templateEngine;
+    private readonly IUserInput _userInput;
     
-    public RunTemplateCommand(IClipboard clipboard, ITemplateProvider templateProvider, ITemplateEngine templateEngine, IFileSystem fileSystem) : base(clipboard, fileSystem)
+    public RunTemplateCommand(IClipboard clipboard, ITemplateProvider templateProvider, ITemplateEngine templateEngine, IFileSystem fileSystem, IUserInput userInput) : base(clipboard, fileSystem)
     {
         Guard.IsNotNull(templateProvider);
         Guard.IsNotNull(templateEngine);
+        Guard.IsNotNull(userInput);
 
         _templateProvider = templateProvider;
         _templateEngine = templateEngine;
+        _userInput = userInput;
     }
 
     public override void Initialize(CommandLineApplication app)
@@ -29,6 +32,7 @@ public class RunTemplateCommand : CommandBase
             var defaultFilenameOption = command.Option<string>("-d|--default", "Default filename", CommandOptionType.SingleValue);
             var currentDirectoryOption = command.Option<string>("-i|--directory", "Current directory", CommandOptionType.SingleValue);
             var parametersArgument = command.Argument("Parameters", "Optional parameters to use (name:value)", true);
+            var interactiveOption = command.Option<string>("-i|--interactive", "Fill parameters interactively", CommandOptionType.NoValue);
             var bareOption = command.Option<bool>("-b|--bare", "Bare output (only template output)", CommandOptionType.NoValue);
             var clipboardOption = command.Option<bool>("-c|--clipboard", "Copy output to clipboard", CommandOptionType.NoValue);
             command.HelpOption();
@@ -52,17 +56,19 @@ public class RunTemplateCommand : CommandBase
                 var basePath = GetBasePath(basePathOption.Value());
                 var defaultFilename = GetDefaultFilename(defaultFilenameOption.Value());
                 var dryRun = GetDryRun(dryRunOption.HasValue(), clipboardOption.HasValue());
-                var parameters = parametersArgument.Values
-                    .Where(p => p?.Contains(':', StringComparison.CurrentCulture) == true)
-                    .Select(p => p!.Split(':'))
-                    .Select(p => new KeyValuePair<string, object?>(p[0], string.Join(":", p.Skip(1))))
-                    .ToArray();
+                var parameters = GetParameters(parametersArgument);
+
                 Watch(app, watchOption.HasValue(), assemblyName, () =>
                 {
                     var generationEnvironment = new MultipleContentBuilderEnvironment();
                     var createTemplateRequest = GetCreateTemplateRequest(assemblyName, className!, currentDirectory);
 
                     var template = _templateProvider.Create(createTemplateRequest);
+                    if (interactiveOption.HasValue())
+                    {
+                        parameters = MergeParameters(parameters, GetInteractiveParameterValues(_templateEngine.GetParameters(template)));
+                    }
+
                     _templateEngine.Render(new RenderTemplateRequest(template, null, generationEnvironment, defaultFilename, parameters, null));
                     WriteOutput(app, generationEnvironment, basePath, bareOption.HasValue(), clipboardOption.HasValue(), dryRun);
                 });
@@ -70,8 +76,34 @@ public class RunTemplateCommand : CommandBase
         });
     }
 
+    private static KeyValuePair<string, object?>[] GetParameters(CommandArgument parametersArgument)
+        => parametersArgument.Values
+            .Where(p => p?.Contains(':', StringComparison.CurrentCulture) == true)
+            .Select(p => p!.Split(':'))
+            .Select(p => new KeyValuePair<string, object?>(p[0], string.Join(":", p.Skip(1))))
+            .ToArray();
+
+    private KeyValuePair<string, object?>[] GetInteractiveParameterValues(ITemplateParameter[] templateParameters)
+    {
+        var list = new List<KeyValuePair<string, object?>>();
+        foreach (var templateParameter in templateParameters)
+        {
+            var value = _userInput.GetValue(templateParameter);
+            list.Add(new KeyValuePair<string, object?>(templateParameter.Name, value));
+        }
+
+        return list.ToArray();
+    }
+
     private static CreateCompiledTemplateRequest GetCreateTemplateRequest(string assemblyName, string className, string? currentDirectory)
         => string.IsNullOrEmpty(currentDirectory)
             ? new CreateCompiledTemplateRequest(assemblyName, className!)
             : new CreateCompiledTemplateRequest(assemblyName, className!, currentDirectory);
+
+    private KeyValuePair<string, object?>[] MergeParameters(KeyValuePair<string, object?>[] parameters, KeyValuePair<string, object?>[] extractedTemplateParameters)
+        => parameters
+            .Concat(extractedTemplateParameters)
+            .GroupBy(t => t.Key)
+            .Select(x => new KeyValuePair<string, object?>(x.Key, x.First().Value))
+            .ToArray();
 }

--- a/src/Console/Properties/launchSettings.json
+++ b/src/Console/Properties/launchSettings.json
@@ -3,7 +3,8 @@
     "TemplateFramework.Console": {
         "commandName": "Project",
         //"commandLineArgs": "assembly --name templateframework.core.codegeneration.tests --directory D:\\git\\TemplateFramework\\src\\Core.CodeGeneration.Tests\\bin\\debug\\net7.0 --dryrun --default myfile.txt --filter TemplateFramework.Core.CodeGeneration.Tests.MyGeneratorProvider"
-        "commandLineArgs": "template --assembly templateframework.core.tests --classname TemplateFramework.Core.Tests.PlainTemplateWithAdditionalParameters --directory D:\\git\\TemplateFramework\\src\\Core.Tests\\bin\\debug\\net7.0 --dryrun --default myfile.txt --interactive"
+        //"commandLineArgs": "template --assembly templateframework.core.tests --classname TemplateFramework.Core.Tests.PlainTemplateWithAdditionalParameters --directory D:\\git\\TemplateFramework\\src\\Core.Tests\\bin\\debug\\net7.0 --dryrun --default myfile.txt --interactive"
+        "commandLineArgs": "template --assembly templateframework.templateproviders.formattablestringtemplateprovider.tests --classname TemplateFramework.TemplateProviders.FormattableStringTemplateProvider.Tests.TestFormattableStringTemplate --directory D:\\git\\TemplateFramework\\src\\TemplateProviders.FormattableStringTemplateProvider.Tests\\bin\\debug\\net7.0 --dryrun --default myfile.txt --interactive"
     }
   }
 }

--- a/src/Console/Properties/launchSettings.json
+++ b/src/Console/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "TemplateFramework.Console": {
         "commandName": "Project",
-        //"commandLineArgs": "assembly --name templateframework.core.codegeneration.tests --directory D:\\git\\TemplateFramework\\src\\Core.CodeGeneration.Tests\\bin\\debug\\net7.0 --dryrun --default myfile.txt"
-        "commandLineArgs": "template --assembly templateframework.core.tests --classname TemplateFramework.Core.Tests.PlainTemplateWithAdditionalParameters --directory D:\\git\\TemplateFramework\\src\\Core.Tests\\bin\\debug\\net7.0 --dryrun --default myfile.txt \"AdditionalParameter:Hello world!\""
+        "commandLineArgs": "assembly --name templateframework.core.codegeneration.tests --directory D:\\git\\TemplateFramework\\src\\Core.CodeGeneration.Tests\\bin\\debug\\net7.0 --dryrun --default myfile.txt --filter TemplateFramework.Core.CodeGeneration.Tests.MyGeneratorProvider"
+        //"commandLineArgs": "template --assembly templateframework.core.tests --classname TemplateFramework.Core.Tests.PlainTemplateWithAdditionalParameters --directory D:\\git\\TemplateFramework\\src\\Core.Tests\\bin\\debug\\net7.0 --dryrun --default myfile.txt \"AdditionalParameter:Hello world!\""
     }
   }
 }

--- a/src/Console/Properties/launchSettings.json
+++ b/src/Console/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "TemplateFramework.Console": {
         "commandName": "Project",
-        "commandLineArgs": "assembly --name templateframework.core.codegeneration.tests --directory D:\\git\\TemplateFramework\\src\\Core.CodeGeneration.Tests\\bin\\debug\\net7.0 --dryrun --default myfile.txt --filter TemplateFramework.Core.CodeGeneration.Tests.MyGeneratorProvider"
-        //"commandLineArgs": "template --assembly templateframework.core.tests --classname TemplateFramework.Core.Tests.PlainTemplateWithAdditionalParameters --directory D:\\git\\TemplateFramework\\src\\Core.Tests\\bin\\debug\\net7.0 --dryrun --default myfile.txt \"AdditionalParameter:Hello world!\""
+        //"commandLineArgs": "assembly --name templateframework.core.codegeneration.tests --directory D:\\git\\TemplateFramework\\src\\Core.CodeGeneration.Tests\\bin\\debug\\net7.0 --dryrun --default myfile.txt --filter TemplateFramework.Core.CodeGeneration.Tests.MyGeneratorProvider"
+        "commandLineArgs": "template --assembly templateframework.core.tests --classname TemplateFramework.Core.Tests.PlainTemplateWithAdditionalParameters --directory D:\\git\\TemplateFramework\\src\\Core.Tests\\bin\\debug\\net7.0 --dryrun --default myfile.txt --interactive"
     }
   }
 }

--- a/src/Console/TemplateFramework.Console.csproj
+++ b/src/Console/TemplateFramework.Console.csproj
@@ -42,6 +42,7 @@
     <Using Include="TemplateFramework.Abstractions" />
     <Using Include="TemplateFramework.Abstractions.CodeGeneration" />
     <Using Include="TemplateFramework.Abstractions.Infrastructure" />
+    <Using Include="TemplateFramework.Abstractions.Templates" />
     <Using Include="TemplateFramework.Console.Abstractions" />
     <Using Include="TemplateFramework.Console.Commands" />
     <Using Include="TemplateFramework.Console.Extensions" />

--- a/src/Console/UserInput.cs
+++ b/src/Console/UserInput.cs
@@ -3,7 +3,7 @@
 [ExcludeFromCodeCoverage]
 public class UserInput : IUserInput
 {
-    public string GetValue(TemplateParameter parameter)
+    public string GetValue(ITemplateParameter parameter)
     {
         Guard.IsNotNull(parameter);
 

--- a/src/Core.CodeGeneration.Tests/CodeGenerationAssemblySettings/CodeGenerationAssemblySettingsTests.Constructor.cs
+++ b/src/Core.CodeGeneration.Tests/CodeGenerationAssemblySettings/CodeGenerationAssemblySettingsTests.Constructor.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel.Design.Serialization;
-
-namespace TemplateFramework.Core.CodeGeneration.Tests;
+﻿namespace TemplateFramework.Core.CodeGeneration.Tests;
 
 public partial class CodeGenerationAssemblySettingsTests
 {

--- a/src/Core.CodeGeneration.Tests/IntegrationTests.cs
+++ b/src/Core.CodeGeneration.Tests/IntegrationTests.cs
@@ -16,7 +16,7 @@ public class IntegrationTests
         var sut = serviceProvider.GetRequiredService<ICodeGenerationEngine>();
         var codeGenerationProvider = new IntegrationProvider();
         var builder = new MultipleContentBuilder();
-        var generationEnvironment = new MultipleContentBuilderEnvironment(serviceProvider.GetRequiredService<IFileSystem>(), builder);
+        var generationEnvironment = new MultipleContentBuilderEnvironment(serviceProvider.GetRequiredService<IFileSystem>(), serviceProvider.GetRequiredService<IRetryMechanism>(), builder);
 
         // Act
         sut.Generate(codeGenerationProvider, generationEnvironment, new CodeGenerationSettings(TestData.BasePath, "DefaultFilename.txt", false));

--- a/src/Core.Tests/Extensions/StringBuilderTemplateExtensionsTests.cs
+++ b/src/Core.Tests/Extensions/StringBuilderTemplateExtensionsTests.cs
@@ -1,0 +1,74 @@
+﻿namespace TemplateFramework.Core.Tests.Extensions;
+
+public class StringBuilderTemplateExtensionsTests
+{
+    protected Mock<IStringBuilderTemplate> SutMock { get; } = new();
+    protected Mock<IMultipleContentBuilder> MultipleContentBuilderMock { get; } = new();
+    protected Mock<IContentBuilder> ContentBuilderMock { get; } = new();
+
+    protected const string DefaultFilename = "MyFile.txt";
+    protected const bool SkipWhenFileExists = true;
+    protected StringBuilder StringBuilder { get; } = new();
+
+    public class RenderToMultipleContentBuilder_Without_SkipWhenFileExists_Argument : StringBuilderTemplateExtensionsTests
+    {
+        [Fact]
+        public void Creates_New_Content_When_DefaultFile_Is_Not_Present_Yet()
+        {
+            // Arrange
+            MultipleContentBuilderMock.SetupGet(x => x.Contents).Returns(new[] { ContentBuilderMock.Object });
+
+            SutMock.Setup(x => x.Render(It.IsAny<StringBuilder>())).Callback(() => StringBuilder.Append("Added data"));
+
+            // Act
+            SutMock.Object.RenderToMultipleContentBuilder(MultipleContentBuilderMock.Object, DefaultFilename);
+
+            // Assert
+            MultipleContentBuilderMock.Verify(x => x.AddContent(DefaultFilename, false, It.IsAny<StringBuilder>()), Times.Once);
+        }
+    }
+
+    public class RenderToMultipleContentBuilder_With_SkipWhenFileExists_Argument : StringBuilderTemplateExtensionsTests
+    {
+        [Fact]
+        public void Throws_On_Null_Builder()
+        {
+            // Act & Assert
+            SutMock.Object.Invoking(x => x.RenderToMultipleContentBuilder(builder: null!, DefaultFilename, SkipWhenFileExists))
+                          .Should().Throw<ArgumentNullException>().WithParameterName("builder");
+        }
+
+        [Fact]
+        public void Appends_Data_To_Content_Of_DefaultFile_When_Present()
+        {
+            // Arrange
+            MultipleContentBuilderMock.SetupGet(x => x.Contents).Returns(new[] { ContentBuilderMock.Object });
+            ContentBuilderMock.SetupGet(x => x.Filename).Returns(DefaultFilename);
+            ContentBuilderMock.SetupGet(x => x.Builder).Returns(StringBuilder);
+            StringBuilder.AppendLine("Initial data");
+            SutMock.Setup(x => x.Render(It.IsAny<StringBuilder>())).Callback(() => StringBuilder.Append("Added data"));
+
+            // Act
+            SutMock.Object.RenderToMultipleContentBuilder(MultipleContentBuilderMock.Object, DefaultFilename, SkipWhenFileExists);
+
+            // Assert
+            StringBuilder.ToString().Should().Be(@"Initial data
+Added data");
+        }
+
+        [Fact]
+        public void Creates_New_Content_When_DefaultFile_Is_Not_Present_Yet()
+        {
+            // Arrange
+            MultipleContentBuilderMock.SetupGet(x => x.Contents).Returns(new[] { ContentBuilderMock.Object });
+
+            SutMock.Setup(x => x.Render(It.IsAny<StringBuilder>())).Callback(() => StringBuilder.Append("Added data"));
+
+            // Act
+            SutMock.Object.RenderToMultipleContentBuilder(MultipleContentBuilderMock.Object, DefaultFilename, SkipWhenFileExists);
+
+            // Assert
+            MultipleContentBuilderMock.Verify(x => x.AddContent(DefaultFilename, SkipWhenFileExists, It.IsAny<StringBuilder>()), Times.Once);
+        }
+    }
+}

--- a/src/Core.Tests/GenerationEnvironments/MultipleContentBuilderEnvironment/MultipleContentBuilderEnvironmentTests.Constructor.cs
+++ b/src/Core.Tests/GenerationEnvironments/MultipleContentBuilderEnvironment/MultipleContentBuilderEnvironmentTests.Constructor.cs
@@ -8,7 +8,7 @@ public partial class MultipleContentBuilderEnvironmentTests
         public void Throws_On_Null_Builder()
         {
             // Act & Assert
-            this.Invoking(_ => new MultipleContentBuilderEnvironment(FileSystemMock.Object, builder: null!))
+            this.Invoking(_ => new MultipleContentBuilderEnvironment(FileSystemMock.Object, RetryMechanism, builder: null!))
                 .Should().Throw<ArgumentNullException>().WithParameterName("builder");
         }
 

--- a/src/Core.Tests/GenerationEnvironments/MultipleContentBuilderEnvironment/MultipleContentBuilderEnvironmentTests.cs
+++ b/src/Core.Tests/GenerationEnvironments/MultipleContentBuilderEnvironment/MultipleContentBuilderEnvironmentTests.cs
@@ -7,8 +7,9 @@ public partial class MultipleContentBuilderEnvironmentTests
     protected Mock<IMultipleContentBuilder> MultipleContentBuilderMock { get; } = new();
     protected Mock<IMultipleContent> MultipleContentMock { get; } = new();
     protected Mock<IContent> ContentMock { get; } = new();
+    protected IRetryMechanism RetryMechanism { get; } = new FastRetryMechanism();
 
-    protected MultipleContentBuilderEnvironment CreateSut() => new(FileSystemMock.Object, MultipleContentBuilderMock.Object);
+    protected MultipleContentBuilderEnvironment CreateSut() => new(FileSystemMock.Object, RetryMechanism, MultipleContentBuilderMock.Object);
 
     protected IEnumerable<IContent> CreateContents(bool skipWhenFileExists = false)
     {
@@ -18,5 +19,10 @@ public partial class MultipleContentBuilderEnvironmentTests
         var c2 = builder.AddContent("File2.txt", skipWhenFileExists: skipWhenFileExists);
         c2.Builder.AppendLine("Test2");
         return builder.Build().Contents;
+    }
+
+    private sealed class FastRetryMechanism : RetryMechanism
+    {
+        protected override int WaitTimeInMs => 1;
     }
 }

--- a/src/Core.Tests/MultipleContentBuilderWrapperTests.cs
+++ b/src/Core.Tests/MultipleContentBuilderWrapperTests.cs
@@ -120,9 +120,7 @@ public class MultipleContentBuilderWrapperTests
 
         public IEnumerable<IContentBuilder>? Contents => _list;
 
-#pragma warning disable S3241 // Methods should not return values that are never used
         public IContentBuilder AddContent(string filename, bool skipWhenFileExists, StringBuilder? builder)
-#pragma warning restore S3241 // Methods should not return values that are never used
         {
             var contentBuilder = new MyContentBuilder
             {

--- a/src/Core.Tests/RetryMechanismTests.cs
+++ b/src/Core.Tests/RetryMechanismTests.cs
@@ -1,0 +1,31 @@
+﻿namespace TemplateFramework.Core.Tests;
+
+public class RetryMechanismTests
+{
+    [Fact]
+    public void Retry_Retries_When_Exception_Occurs()
+    {
+        // Arrange
+        var sut = new FastRetryMechanism();
+        int counter = 0;
+
+        // Act
+        sut.Retry(() =>
+        {
+            counter++;
+
+            if (counter == 1)
+            {
+                throw new IOException("Can't write to file because it is being used by another process");
+            }
+        });
+
+        // Assert
+        counter.Should().Be(2);
+    }
+
+    private sealed class FastRetryMechanism : RetryMechanism
+    {
+        protected override int WaitTimeInMs => 1;
+    }
+}

--- a/src/Core.Tests/TemplateEngine/TemplateEngineTests.Constructor.cs
+++ b/src/Core.Tests/TemplateEngine/TemplateEngineTests.Constructor.cs
@@ -8,15 +8,23 @@ public partial class TemplateEngineTests
         public void Throws_On_Null_TemplateInitializer()
         {
             // Act & Assert
-            this.Invoking(_ => new TemplateEngine(templateInitializer: null!, Enumerable.Empty<ITemplateRenderer>()))
+            this.Invoking(_ => new TemplateEngine(templateInitializer: null!, TemplateParameterExtractorMock.Object, Enumerable.Empty<ITemplateRenderer>()))
                 .Should().Throw<ArgumentNullException>().WithParameterName("templateInitializer");
         }
-        
+
+        [Fact]
+        public void Throws_On_Null_TemplateParameterExtractor()
+        {
+            // Act & Assert
+            this.Invoking(_ => new TemplateEngine(TemplateInitializerMock.Object, templateParameterExtractor: null!, Enumerable.Empty<ITemplateRenderer>()))
+                .Should().Throw<ArgumentNullException>().WithParameterName("templateParameterExtractor");
+        }
+
         [Fact]
         public void Throws_On_Null_TemplateRenderers()
         {
             // Act & Assert
-            this.Invoking(_ => new TemplateEngine(TemplateInitializerMock.Object, templateRenderers: null!))
+            this.Invoking(_ => new TemplateEngine(TemplateInitializerMock.Object, TemplateParameterExtractorMock.Object, templateRenderers: null!))
                 .Should().Throw<ArgumentNullException>().WithParameterName("templateRenderers");
         }
     }

--- a/src/Core.Tests/TemplateEngine/TemplateEngineTests.GetParameters.cs
+++ b/src/Core.Tests/TemplateEngine/TemplateEngineTests.GetParameters.cs
@@ -1,0 +1,34 @@
+﻿namespace TemplateFramework.Core.Tests;
+
+public partial class TemplateEngineTests
+{
+    public class GetParameters : TemplateEngineTests
+    {
+        [Fact]
+        public void Throws_On_Null_TemplateInstance()
+        {
+            // Arrange
+            var sut = CreateSut();
+
+            // Act & Assert
+            sut.Invoking(x => x.GetParameters(templateInstance: null!))
+               .Should().Throw<ArgumentNullException>().WithParameterName("templateInstance");
+        }
+
+        [Fact]
+        public void Returns_Correct_TemplateParameters_From_TemplateInstance_When_Not_Null()
+        {
+            // Arrange
+            var sut = CreateSut();
+            var template = new object();
+            var parameters = new[] { new TemplateParameter("name", typeof(string)) };
+            TemplateParameterExtractorMock.Setup(x => x.Extract(template)).Returns(parameters);
+
+            // Act
+            var result = sut.GetParameters(template);
+
+            // Assert
+            result.Should().BeEquivalentTo(parameters);
+        }
+    }
+}

--- a/src/Core.Tests/TemplateEngine/TemplateEngineTests.Render.UnsupportedGenerationEnvironmentType.cs
+++ b/src/Core.Tests/TemplateEngine/TemplateEngineTests.Render.UnsupportedGenerationEnvironmentType.cs
@@ -8,7 +8,7 @@ public partial class TemplateEngineTests
         public void Throws()
         {
             // Arrange
-            var sut = new TemplateEngine(TemplateInitializerMock.Object, Array.Empty<ITemplateRenderer>()); // we are specifying here that no renderers are known, so even StringBuilder throws an exception :)
+            var sut = new TemplateEngine(TemplateInitializerMock.Object, TemplateParameterExtractorMock.Object, Array.Empty<ITemplateRenderer>()); // we are specifying here that no renderers are known, so even StringBuilder throws an exception :)
             var request = new RenderTemplateRequest(new TestData.Template(_ => { }), new StringBuilder()); // note that we can't put a non-supported type in here because the interface prevents that. But the construction above accomplishes that.
 
             // Act & Assert

--- a/src/Core.Tests/TemplateEngine/TemplateEngineTests.cs
+++ b/src/Core.Tests/TemplateEngine/TemplateEngineTests.cs
@@ -6,7 +6,8 @@ public partial class TemplateEngineTests
     protected Mock<IMultipleContentBuilder> MultipleContentBuilderMock { get; } = new();
 
     protected Mock<ITemplateInitializer> TemplateInitializerMock { get; } = new();
+    protected Mock<ITemplateParameterExtractor> TemplateParameterExtractorMock { get; } = new();
     protected Mock<ITemplateRenderer> TemplateRendererMock { get; } = new();
 
-    protected TemplateEngine CreateSut() => new(TemplateInitializerMock.Object, new[] { TemplateRendererMock.Object });
+    protected TemplateEngine CreateSut() => new(TemplateInitializerMock.Object, TemplateParameterExtractorMock.Object, new[] { TemplateRendererMock.Object });
 }

--- a/src/Core.Tests/TemplateFramework.Core.Tests.csproj
+++ b/src/Core.Tests/TemplateFramework.Core.Tests.csproj
@@ -63,6 +63,7 @@
     <Using Include="TemplateFramework.Core.Requests" />
     <Using Include="TemplateFramework.Core.StringBuilderTemplateRenderers" />
     <Using Include="TemplateFramework.Core.TemplateInitializerComponents" />
+    <Using Include="TemplateFramework.Core.TemplateParameterExtractorComponents" />
     <Using Include="TemplateFramework.Core.TemplateRenderers" />
     <Using Include="Xunit" />
   </ItemGroup>

--- a/src/Core.Tests/TemplateInitializerComponents/ContextInitializerTests.cs
+++ b/src/Core.Tests/TemplateInitializerComponents/ContextInitializerTests.cs
@@ -12,6 +12,30 @@ public class ContextInitializerTests
     public class Initialize : ContextInitializerTests
     {
         [Fact]
+        public void Throws_On_Null_Request()
+        {
+            // Arrange
+            var sut = CreateSut();
+
+            // Act & Assert
+            sut.Invoking(x => x.Initialize(request: null!, TemplateEngineMock.Object))
+               .Should().Throw<ArgumentNullException>().WithParameterName("request");
+        }
+
+        [Fact]
+        public void Throws_On_Null_Engine()
+        {
+            // Arrange
+            var sut = CreateSut();
+            var template = this;
+            var request = new RenderTemplateRequest(template, null, new StringBuilder(), DefaultFilename);
+
+            // Act & Assert
+            sut.Invoking(x => x.Initialize(request, engine: null!))
+               .Should().Throw<ArgumentNullException>().WithParameterName("engine");
+        }
+
+        [Fact]
         public void Sets_TemplateContext_On_Template_When_Possible()
         {
             // Arrange

--- a/src/Core.Tests/TemplateInitializerComponents/DefaultFilenameInitializerTests.cs
+++ b/src/Core.Tests/TemplateInitializerComponents/DefaultFilenameInitializerTests.cs
@@ -1,26 +1,14 @@
 ﻿namespace TemplateFramework.Core.Tests.TemplateInitializerComponents;
 
-public class ModelInitializerTests
+public class DefaultFilenameInitializerTests
 {
-    protected ModelInitializer CreateSut() => new(ValueConverterMock.Object);
+    protected DefaultFilenameInitializer CreateSut() => new();
     
-    protected Mock<IValueConverter> ValueConverterMock { get; } = new();
     protected Mock<ITemplateEngine> TemplateEngineMock { get; } = new();
     
     protected const string DefaultFilename = "DefaultFilename.txt";
 
-    public class Constructor
-    {
-        [Fact]
-        public void Throws_On_Null_Converter()
-        {
-            // Act & Assert
-            this.Invoking(_ => new ModelInitializer(converter: null!))
-                .Should().Throw<ArgumentNullException>().WithParameterName("converter");
-        }
-    }
-
-    public class Initialize : ModelInitializerTests
+    public class Initialize : DefaultFilenameInitializerTests
     {
         [Fact]
         public void Throws_On_Null_Request()
@@ -47,20 +35,18 @@ public class ModelInitializerTests
         }
 
         [Fact]
-        public void Sets_Model_When_Possible()
+        public void Sets_DefaultFilename_When_Possible()
         {
             // Arrange
             var sut = CreateSut();
-            var model = "Hello world!";
-            var template = new TestData.TemplateWithModel<string>(_ => { });
-            var request = new RenderTemplateRequest(template, model, new StringBuilder(), DefaultFilename);
-            ValueConverterMock.Setup(x => x.Convert(It.IsAny<object?>(), It.IsAny<Type>())).Returns<object?, Type>((value, type) => value);
+            var template = new TestData.TemplateWithDefaultFilename(_ => { });
+            var request = new RenderTemplateRequest(template, null, new StringBuilder(), DefaultFilename);
 
             // Act
             sut.Initialize(request, TemplateEngineMock.Object);
 
             // Assert
-            template.Model.Should().Be(model);
+            template.DefaultFilename.Should().Be(DefaultFilename);
         }
     }
 }

--- a/src/Core.Tests/TemplateInitializerComponents/ParameterInitializerTests.cs
+++ b/src/Core.Tests/TemplateInitializerComponents/ParameterInitializerTests.cs
@@ -23,6 +23,30 @@ public class ParameterInitializerTests
     public class Initialize : ParameterInitializerTests
     {
         [Fact]
+        public void Throws_On_Null_Request()
+        {
+            // Arrange
+            var sut = CreateSut();
+
+            // Act & Assert
+            sut.Invoking(x => x.Initialize(request: null!, TemplateEngineMock.Object))
+               .Should().Throw<ArgumentNullException>().WithParameterName("request");
+        }
+
+        [Fact]
+        public void Throws_On_Null_Engine()
+        {
+            // Arrange
+            var sut = CreateSut();
+            var template = this;
+            var request = new RenderTemplateRequest(template, null, new StringBuilder(), DefaultFilename);
+
+            // Act & Assert
+            sut.Invoking(x => x.Initialize(request, engine: null!))
+               .Should().Throw<ArgumentNullException>().WithParameterName("engine");
+        }
+
+        [Fact]
         public void Sets_AdditionalParameters_When_Template_Implements_IParameterizedTemplate()
         {
             // Arrange

--- a/src/Core.Tests/TemplateParameterExtractorComponents/TypedExtractorTests.cs
+++ b/src/Core.Tests/TemplateParameterExtractorComponents/TypedExtractorTests.cs
@@ -1,0 +1,90 @@
+﻿namespace TemplateFramework.Core.Tests.TemplateParameterExtractorComponents;
+
+public class TypedExtractorTests
+{
+    protected TypedExtractor CreateSut() => new();
+
+    protected Mock<IParameterizedTemplate> ParameterizedTemplateMock { get; } = new();
+
+    public class Extract : TypedExtractorTests
+    {
+        [Fact]
+        public void Throws_On_Null_TemplateInstance()
+        {
+            // Arrange
+            var sut = CreateSut();
+
+            // Act & Assert
+            sut.Invoking(x => x.Extract(templateInstance: null!))
+               .Should().Throw<ArgumentNullException>().WithParameterName("templateInstance");
+        }
+
+        [Fact]
+        public void Throws_On_TemplateInstance_Of_Wrong_Type()
+        {
+            // Arrange
+            var sut = CreateSut();
+
+            // Act & Assert
+            sut.Invoking(x => x.Extract(templateInstance: new object()))
+               .Should().Throw<ArgumentException>().WithParameterName("templateInstance");
+        }
+
+        [Fact]
+        public void Returns_Result_From_TemplateInstance_When_It_Implements_IParameterizedTemplate()
+        {
+            // Arrange
+            var sut = CreateSut();
+            var parameters = new[] { new TemplateParameter("SomeName", typeof(string)) };
+            ParameterizedTemplateMock.Setup(x => x.GetParameters()).Returns(parameters);
+
+            // Act
+            var result = sut.Extract(ParameterizedTemplateMock.Object);
+
+            // Assert
+            result.Should().BeEquivalentTo(parameters);
+        }
+    }
+
+    public class Supports : TypedExtractorTests
+    {
+        [Fact]
+        public void Returns_True_When_Template_Implements_IParameterizedTemplate()
+        {
+            // Arrange
+            var sut = CreateSut();
+
+            // Act
+            var result = sut.Supports(ParameterizedTemplateMock.Object);
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Returns_False_When_Template_Is_Null()
+        {
+            // Arrange
+            var sut = CreateSut();
+
+            // Act
+            var result = sut.Supports(null!);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Returns_False_When_Template_Is_Not_Null_But_Does_Not_Implement_IParameterizedTemplate()
+        {
+            // Arrange
+            var sut = CreateSut();
+
+            // Act
+            var result = sut.Supports(new object());
+
+            // Assert
+            result.Should().BeFalse();
+        }
+    }
+}

--- a/src/Core.Tests/TemplateParameterExtractorTests.cs
+++ b/src/Core.Tests/TemplateParameterExtractorTests.cs
@@ -1,0 +1,60 @@
+﻿namespace TemplateFramework.Core.Tests;
+
+public class TemplateParameterExtractorTests
+{
+    protected TemplateParameterExtractor CreateSut() => new(new[] { TemplateParameterExtractorComponentMock.Object });
+
+    protected Mock<ITemplateParameterExtractorComponent> TemplateParameterExtractorComponentMock { get; } = new();
+
+    public class Constructor
+    {
+        [Fact]
+        public void Throws_On_Null_Components()
+        {
+            // Act & Assert
+            this.Invoking(_ => new TemplateParameterExtractor(components: null!))
+                .Should().Throw<ArgumentNullException>().WithParameterName("components");
+        }
+    }
+    public class Extract : TemplateParameterExtractorTests
+    {
+        [Fact]
+        public void Throws_On_Null_TemplateInstance()
+        {
+            // Arrange
+            var sut = CreateSut();
+
+            // Act & Assert
+            sut.Invoking(x => x.Extract(templateInstance: null!))
+               .Should().Throw<ArgumentNullException>().WithParameterName("templateInstance");
+        }
+
+        [Fact]
+        public void Throws_On_Unsupported_Type()
+        {
+            // Arrange
+            var sut = CreateSut();
+
+            // Act & Assert
+            sut.Invoking(x => x.Extract(templateInstance: new object()))
+               .Should().Throw<NotSupportedException>();
+        }
+
+        [Fact]
+        public void Returns_Result_From_Component_On_Supported_Type()
+        {
+            // Arrange
+            var sut = CreateSut();
+            var template = new object();
+            var parameters = new[] { new TemplateParameter("name", typeof(string)) };
+            TemplateParameterExtractorComponentMock.Setup(x => x.Supports(template)).Returns(true);
+            TemplateParameterExtractorComponentMock.Setup(x => x.Extract(template)).Returns(parameters);
+
+            // Act
+            var result = sut.Extract(template);
+
+            // Assert
+            result.Should().BeEquivalentTo(parameters);
+        }
+    }
+}

--- a/src/Core.Tests/TemplateProviderTests.cs
+++ b/src/Core.Tests/TemplateProviderTests.cs
@@ -41,7 +41,7 @@ public class TemplateProviderTests
         }
 
         [Fact]
-        public void Returns_Template_Instance_From_Provider_On_Supported_Type()
+        public void Returns_Template_Instance_From_Component_On_Supported_Type()
         {
             // Arrange
             var sut = CreateSut();

--- a/src/Core.Tests/TestData.cs
+++ b/src/Core.Tests/TestData.cs
@@ -49,6 +49,17 @@ internal static class TestData
         public void Render(StringBuilder builder) => _delegate(builder);
     }
 
+    internal sealed class TemplateWithDefaultFilename : IStringBuilderTemplate, IDefaultFilenameContainer
+    {
+        private readonly Action<StringBuilder> _delegate;
+
+        public TemplateWithDefaultFilename(Action<StringBuilder> @delegate) => _delegate = @delegate;
+
+        public string DefaultFilename { get; set; } = "";
+
+        public void Render(StringBuilder builder) => _delegate(builder);
+    }
+
     internal sealed class TemplateWithViewModel<T> : IStringBuilderTemplate, IParameterizedTemplate
     {
         public T? ViewModel { get; set; } = default!;

--- a/src/Core.Tests/TestEnum.cs
+++ b/src/Core.Tests/TestEnum.cs
@@ -1,8 +1,6 @@
 ﻿namespace TemplateFramework.Core.Tests;
 
-#pragma warning disable S2344 // Enumeration type names should not have "Flags" or "Enum" suffixes
 internal enum TestEnum
-#pragma warning restore S2344 // Enumeration type names should not have "Flags" or "Enum" suffixes
 {
     FirstValue = 0,
     SecondValue = 1

--- a/src/Core/Abstractions/IRetryMechanism.cs
+++ b/src/Core/Abstractions/IRetryMechanism.cs
@@ -1,0 +1,6 @@
+﻿namespace TemplateFramework.Core.Abstractions;
+
+public interface IRetryMechanism
+{
+    void Retry(Action action);
+}

--- a/src/Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Core/Extensions/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ public static class ServiceCollectionExtensions
             .AddSingleton<IValueConverter, ValueConverter>()
             .AddSingleton<ITemplateProvider, TemplateProvider>()
             .AddSingleton<IRetryMechanism, RetryMechanism>()
+            .AddSingleton<ITemplateParameterExtractor, TemplateParameterExtractor>()
             .AddSingleton<ISingleContentTemplateRenderer, StringBuilderTemplateRenderer>() // also register using its own type, so we can render a single template from  multiple content template renderer
             ;
 }

--- a/src/Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Core/Extensions/ServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ public static class ServiceCollectionExtensions
             .AddSingleton<ITemplateInitializerComponent, ModelInitializer>()
             .AddSingleton<ITemplateInitializerComponent, ParameterInitializer>()
             .AddSingleton<ITemplateInitializerComponent, ContextInitializer>()
+            .AddSingleton<ITemplateInitializerComponent, DefaultFilenameInitializer>()
             .AddSingleton<IValueConverter, ValueConverter>()
             .AddSingleton<ITemplateProvider, TemplateProvider>()
             .AddSingleton<IRetryMechanism, RetryMechanism>()

--- a/src/Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Core/Extensions/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ public static class ServiceCollectionExtensions
             .AddSingleton<ITemplateInitializerComponent, ContextInitializer>()
             .AddSingleton<IValueConverter, ValueConverter>()
             .AddSingleton<ITemplateProvider, TemplateProvider>()
+            .AddSingleton<IRetryMechanism, RetryMechanism>()
             .AddSingleton<ISingleContentTemplateRenderer, StringBuilderTemplateRenderer>() // also register using its own type, so we can render a single template from  multiple content template renderer
             ;
 }

--- a/src/Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Core/Extensions/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ public static class ServiceCollectionExtensions
             .AddSingleton<ITemplateInitializerComponent, ParameterInitializer>()
             .AddSingleton<ITemplateInitializerComponent, ContextInitializer>()
             .AddSingleton<ITemplateInitializerComponent, DefaultFilenameInitializer>()
+            .AddSingleton<ITemplateParameterExtractorComponent, TypedExtractor>()
             .AddSingleton<IValueConverter, ValueConverter>()
             .AddSingleton<ITemplateProvider, TemplateProvider>()
             .AddSingleton<IRetryMechanism, RetryMechanism>()

--- a/src/Core/Extensions/StringBuilderTemplateExtensions.cs
+++ b/src/Core/Extensions/StringBuilderTemplateExtensions.cs
@@ -1,0 +1,30 @@
+﻿namespace TemplateFramework.Core.Extensions;
+
+public static class StringBuilderTemplateExtensions
+{
+    public static void RenderToMultipleContentBuilder(this IStringBuilderTemplate instance,
+                                                      IMultipleContentBuilder builder,
+                                                      string defaultFilename)
+        => instance.RenderToMultipleContentBuilder(builder, defaultFilename, false);
+
+    public static void RenderToMultipleContentBuilder(this IStringBuilderTemplate instance,
+                                                      IMultipleContentBuilder builder,
+                                                      string defaultFilename,
+                                                      bool skipWhenFileExists)
+    {
+        Guard.IsNotNull(builder);
+
+        var stringBuilder = new StringBuilder();
+        instance.Render(stringBuilder);
+
+        var content = builder.Contents.FirstOrDefault(x => x.Filename == defaultFilename);
+        if (content is not null)
+        {
+            content.Builder.Append(stringBuilder);
+        }
+        else
+        {
+            builder.AddContent(defaultFilename, skipWhenFileExists, stringBuilder);
+        }
+    }
+}

--- a/src/Core/RetryMechanism.cs
+++ b/src/Core/RetryMechanism.cs
@@ -2,6 +2,7 @@
 
 public class RetryMechanism : IRetryMechanism
 {
+    [ExcludeFromCodeCoverage]
     protected virtual int WaitTimeInMs => 500;
 
     public void Retry(Action action)

--- a/src/Core/RetryMechanism.cs
+++ b/src/Core/RetryMechanism.cs
@@ -1,0 +1,24 @@
+﻿namespace TemplateFramework.Core;
+
+public class RetryMechanism : IRetryMechanism
+{
+    protected virtual int WaitTimeInMs => 500;
+
+    public void Retry(Action action)
+    {
+        Guard.IsNotNull(action);
+
+        for (int i = 1; i <= 3; i++)
+        {
+            try
+            {
+                action();
+                return;
+            }
+            catch (IOException x) when (x.Message.Contains("because it is being used by another process", StringComparison.InvariantCulture))
+            {
+                Thread.Sleep(i * WaitTimeInMs);
+            }
+        }
+    }
+}

--- a/src/Core/TemplateEngine.cs
+++ b/src/Core/TemplateEngine.cs
@@ -3,14 +3,28 @@
 public sealed class TemplateEngine : ITemplateEngine
 {
     private readonly ITemplateInitializer _templateInitializer;
+    private readonly ITemplateParameterExtractor _templateParameterExtractor;
     private readonly IEnumerable<ITemplateRenderer> _templateRenderers;
 
-    public TemplateEngine(ITemplateInitializer templateInitializer, IEnumerable<ITemplateRenderer> templateRenderers)
+    public TemplateEngine(
+        ITemplateInitializer templateInitializer,
+        ITemplateParameterExtractor templateParameterExtractor,
+        IEnumerable<ITemplateRenderer> templateRenderers)
     {
         Guard.IsNotNull(templateInitializer);
+        Guard.IsNotNull(templateParameterExtractor);
         Guard.IsNotNull(templateRenderers);
+
         _templateInitializer = templateInitializer;
+        _templateParameterExtractor = templateParameterExtractor;
         _templateRenderers = templateRenderers;
+    }
+
+    public ITemplateParameter[] GetParameters(object templateInstance)
+    {
+        Guard.IsNotNull(templateInstance);
+
+        return _templateParameterExtractor.Extract(templateInstance);
     }
 
     public void Render(IRenderTemplateRequest request)

--- a/src/Core/TemplateFramework.Core.csproj
+++ b/src/Core/TemplateFramework.Core.csproj
@@ -57,6 +57,7 @@
     <Using Include="TemplateFramework.Core.Requests" />
     <Using Include="TemplateFramework.Core.StringBuilderTemplateRenderers" />
     <Using Include="TemplateFramework.Core.TemplateInitializerComponents" />
+    <Using Include="TemplateFramework.Core.TemplateParameterExtractorComponents" />
     <Using Include="TemplateFramework.Core.TemplateRenderers" />
   </ItemGroup>
 

--- a/src/Core/TemplateInitializerComponents/DefaultFilenameInitializer.cs
+++ b/src/Core/TemplateInitializerComponents/DefaultFilenameInitializer.cs
@@ -1,0 +1,18 @@
+﻿namespace TemplateFramework.Core.TemplateInitializerComponents;
+
+public class DefaultFilenameInitializer : ITemplateInitializerComponent
+{
+    public void Initialize(IRenderTemplateRequest request, ITemplateEngine engine)
+    {
+        Guard.IsNotNull(request);
+        Guard.IsNotNull(engine);
+
+        var templateType = request.Template.GetType();
+
+        if (Array.Exists(templateType.GetInterfaces(), t => t.FullName?.Equals(typeof(IDefaultFilenameContainer).FullName, StringComparison.Ordinal) == true))
+        {
+            var defaultFilenameProperty = templateType.GetProperty(nameof(IDefaultFilenameContainer.DefaultFilename))!;
+            defaultFilenameProperty.SetValue(request.Template, request.DefaultFilename);
+        }
+    }
+}

--- a/src/Core/TemplateParameterExtractor.cs
+++ b/src/Core/TemplateParameterExtractor.cs
@@ -1,0 +1,26 @@
+﻿namespace TemplateFramework.Core;
+
+public class TemplateParameterExtractor : ITemplateParameterExtractor
+{
+    private readonly IEnumerable<ITemplateParameterExtractorComponent> _components;
+
+    public TemplateParameterExtractor(IEnumerable<ITemplateParameterExtractorComponent> components)
+    {
+        Guard.IsNotNull(components);
+
+        _components = components;
+    }
+
+    public ITemplateParameter[] Extract(object templateInstance)
+    {
+        Guard.IsNotNull(templateInstance);
+
+        var component = _components.FirstOrDefault(x => x.Supports(templateInstance));
+        if (component is null)
+        {
+            throw new NotSupportedException($"Type of create template request ({templateInstance.GetType().FullName}) is not supported");
+        }
+
+        return component.Extract(templateInstance);
+    }
+}

--- a/src/Core/TemplateParameterExtractorComponents/TypedExtractor.cs
+++ b/src/Core/TemplateParameterExtractorComponents/TypedExtractor.cs
@@ -1,0 +1,16 @@
+﻿namespace TemplateFramework.Core.TemplateParameterExtractorComponents;
+
+public class TypedExtractor : ITemplateParameterExtractorComponent
+{
+    public ITemplateParameter[] Extract(object templateInstance)
+    {
+        Guard.IsNotNull(templateInstance);
+        Guard.IsAssignableToType<IParameterizedTemplate>(templateInstance);
+
+        var parameterizedTemplate = (IParameterizedTemplate)templateInstance;
+
+        return parameterizedTemplate.GetParameters();
+    }
+
+    public bool Supports(object templateInstance) => templateInstance is IParameterizedTemplate;
+}

--- a/src/TemplateProviders.ChildTemplateProvider.Tests/IntegrationTests.cs
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/IntegrationTests.cs
@@ -35,12 +35,13 @@ public class IntegrationTests
         using var provider = new ServiceCollection()
             .AddTemplateFramework()
             .AddTemplateFrameworkChildTemplateProvider()
-            .AddChildTemplate("CodeGenerationHeader", _ => new TestData.CodeGenerationHeaderTemplate())
-            .AddChildTemplate("DefaultUsings", _ => new TestData.DefaultUsingsTemplate())
-            .AddChildTemplate(typeof(TestData.TypeBase), _ => new TestData.ClassTemplate())
+            .AddChildTemplate("CodeGenerationHeader", services => new TestData.CodeGenerationHeaderTemplate(services.GetRequiredService<ITemplateEngine>(), services.GetRequiredService<ITemplateProvider>()))
+            .AddChildTemplate("DefaultUsings", services => new TestData.DefaultUsingsTemplate(services.GetRequiredService<ITemplateEngine>(), services.GetRequiredService<ITemplateProvider>()))
+            .AddChildTemplate(typeof(TestData.TypeBase), services => new TestData.ClassTemplate(services.GetRequiredService<ITemplateEngine>(), services.GetRequiredService<ITemplateProvider>()))
+            .AddTransient(services => new TestData.CsharpClassGenerator(services.GetRequiredService<ITemplateEngine>(), services.GetRequiredService<ITemplateProvider>()))
             .BuildServiceProvider();
         var engine = provider.GetRequiredService<ITemplateEngine>();
-        var template = new TestData.CsharpClassGenerator();
+        var template = provider.GetRequiredService<TestData.CsharpClassGenerator>();
         var generationEnvironment = new MultipleContentBuilder();
         var model = new[]
         {

--- a/src/TemplateProviders.ChildTemplateProvider.Tests/IntegrationTests.cs
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/IntegrationTests.cs
@@ -35,11 +35,19 @@ public class IntegrationTests
         using var provider = new ServiceCollection()
             .AddTemplateFramework()
             .AddTemplateFrameworkChildTemplateProvider()
-            .AddChildTemplate("CodeGenerationHeader", services => new TestData.CodeGenerationHeaderTemplate(services.GetRequiredService<ITemplateEngine>(), services.GetRequiredService<ITemplateProvider>()))
-            .AddChildTemplate("DefaultUsings", services => new TestData.DefaultUsingsTemplate(services.GetRequiredService<ITemplateEngine>(), services.GetRequiredService<ITemplateProvider>()))
-            .AddChildTemplate(typeof(TestData.TypeBase), services => new TestData.ClassTemplate(services.GetRequiredService<ITemplateEngine>(), services.GetRequiredService<ITemplateProvider>()))
-            .AddTransient(services => new TestData.CsharpClassGenerator(services.GetRequiredService<ITemplateEngine>(), services.GetRequiredService<ITemplateProvider>()))
+            .AddTransient<TestData.CsharpClassGenerator>()
+
+            // Note that this can be done using reflection maybe, if the list of child templates grows large...
+            .AddTransient<TestData.CodeGenerationHeaderTemplate>()
+            .AddTransient<TestData.DefaultUsingsTemplate>()
+            .AddTransient<TestData.ClassTemplate>()
+
+            .AddChildTemplate<TestData.CodeGenerationHeaderTemplate>("CodeGenerationHeader")
+            .AddChildTemplate<TestData.DefaultUsingsTemplate>("DefaultUsings")
+            .AddChildTemplate<TestData.ClassTemplate>(typeof(TestData.TypeBase))
+
             .BuildServiceProvider();
+
         var engine = provider.GetRequiredService<ITemplateEngine>();
         var template = provider.GetRequiredService<TestData.CsharpClassGenerator>();
         var generationEnvironment = new MultipleContentBuilder();

--- a/src/TemplateProviders.ChildTemplateProvider.Tests/IntegrationTests.cs
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/IntegrationTests.cs
@@ -65,7 +65,7 @@ public class IntegrationTests
         var viewModel = new TestData.CsharpClassGeneratorViewModel<IEnumerable<TestData.TypeBase>>(model, settings);
 
         // Act
-        engine.Render(new RenderTemplateRequest(template, viewModel, generationEnvironment, settings));
+        engine.Render(new RenderTemplateRequest(template, viewModel, generationEnvironment, "GeneratedCode.cs", settings));
 
         // Assert
         generationEnvironment.Contents.Should().HaveCount(4);

--- a/src/TemplateProviders.ChildTemplateProvider.Tests/TestData.cs
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/TestData.cs
@@ -1,6 +1,4 @@
-﻿using static TemplateFramework.TemplateProviders.ChildTemplateProvider.Tests.TestData;
-
-namespace TemplateFramework.TemplateProviders.ChildTemplateProvider.Tests;
+﻿namespace TemplateFramework.TemplateProviders.ChildTemplateProvider.Tests;
 
 internal static class TestData
 {
@@ -90,9 +88,9 @@ internal static class TestData
             => new(false, SkipWhenFileExists, false, null, null, null, false, IndentCount + 1, CultureInfo);
     }
 
-    internal abstract class CsharpClassGeneratorBase<TModel> : IModelContainer<TModel>
+    internal abstract class CsharpClassGeneratorBase<TModel> : IModelContainer<TModel>, IDefaultFilenameContainer
     {
-        protected ITemplateContext Context { get; }
+        protected ITemplateContext Context => new TemplateContext(Engine, Provider, DefaultFilename, this, Model);
         protected ITemplateEngine Engine { get; }
         protected ITemplateProvider Provider { get; }
 
@@ -103,7 +101,6 @@ internal static class TestData
         {
             Engine = engine ?? throw new ArgumentNullException(nameof(engine));
             Provider = provider ?? throw new ArgumentNullException(nameof(provider));
-            Context = new TemplateContext(Engine, Provider, DefaultFilename, this, Model);
         }
     }
 

--- a/src/TemplateProviders.ChildTemplateProvider.Tests/TestData.cs
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/TestData.cs
@@ -104,6 +104,8 @@ internal static class TestData
         }
     }
 
+// False positive, it gets created through DI container
+#pragma warning disable CA1812 // Avoid uninstantiated internal classes
     internal sealed class CsharpClassGenerator : CsharpClassGeneratorBase<CsharpClassGeneratorViewModel<IEnumerable<TypeBase>>>, IMultipleContentBuilderTemplate
     {
         public CsharpClassGenerator(ITemplateEngine engine, ITemplateProvider provider) : base(engine, provider)
@@ -323,6 +325,7 @@ internal static class TestData
             }
         }
     }
+#pragma warning restore CA1812 // Avoid uninstantiated internal classes
 
     internal sealed class TypeBase
     {

--- a/src/TemplateProviders.CompiledTemplateProvider.Tests/TemplateWrapperTests.cs
+++ b/src/TemplateProviders.CompiledTemplateProvider.Tests/TemplateWrapperTests.cs
@@ -85,10 +85,8 @@ public class TemplateWrapperTests
 
         private sealed class TemplateWithTypedParameters
         {
-#pragma warning disable S3459 // Unassigned members should be removed
             public string? Prop1 { get; set; }
             public string? Prop2 { get; set; }
-#pragma warning restore S3459 // Unassigned members should be removed
             public string? Skip1 { get; }
 #pragma warning disable S2376 // Write-only properties should not be used
             public string? Skip2

--- a/src/TemplateProviders.CompiledTemplateProvider.Tests/TemplateWrapperTests.cs
+++ b/src/TemplateProviders.CompiledTemplateProvider.Tests/TemplateWrapperTests.cs
@@ -43,7 +43,7 @@ public class TemplateWrapperTests
         }
 
         [Fact]
-        public void Returns_Empty_Array_When_Wrapped_Instance_Does_Not_Have_GetParameters_Method()
+        public void Returns_Empty_Array_When_Wrapped_Instance_Does_Not_Have_GetParameters_Method_And_Does_Not_Have_Public_Properties()
         {
             // Arrange
             var wrappedInstance = new object();
@@ -57,6 +57,21 @@ public class TemplateWrapperTests
         }
 
         [Fact]
+        public void Returns_Public_Properties_When_Wrapped_Instance_Does_Not_Have_GetParameters_Method_But_Has_Public_Properties()
+        {
+            // Arrange
+            var wrappedInstance = new TemplateWithTypedParameters();
+            var sut = new TemplateWrapper(wrappedInstance);
+
+            // Act
+            var result = sut.GetParameters();
+
+            // Assert
+            result.Select(x => x.Name).Should().BeEquivalentTo(nameof(TemplateWithTypedParameters.Prop1), nameof(TemplateWithTypedParameters.Prop2));
+            result.Select(x => x.Type).Should().AllBeEquivalentTo(typeof(string));
+        }
+
+        [Fact]
         public void Throws_When_Wrapped_Instance_Returns_Result_From_GetParameters_Using_Wrong_Type()
         {
             // Arrange
@@ -66,6 +81,12 @@ public class TemplateWrapperTests
             // Act & Assert
             sut.Invoking(x => x.GetParameters())
                .Should().Throw<NotSupportedException>();
+        }
+
+        private sealed class TemplateWithTypedParameters
+        {
+            public string? Prop1 { get; set; }
+            public string? Prop2 { get; set; }
         }
     }
 

--- a/src/TemplateProviders.CompiledTemplateProvider.Tests/TemplateWrapperTests.cs
+++ b/src/TemplateProviders.CompiledTemplateProvider.Tests/TemplateWrapperTests.cs
@@ -87,6 +87,14 @@ public class TemplateWrapperTests
         {
             public string? Prop1 { get; set; }
             public string? Prop2 { get; set; }
+            public string? Skip1 { get; }
+#pragma warning disable S2376 // Write-only properties should not be used
+#pragma warning disable S3237 // "value" contextual keyword should be used
+#pragma warning disable S108 // Nested blocks of code should not be left empty
+            public string? Skip2 { set { } }
+#pragma warning restore S108 // Nested blocks of code should not be left empty
+#pragma warning restore S3237 // "value" contextual keyword should be used
+#pragma warning restore S2376 // Write-only properties should not be used
         }
     }
 

--- a/src/TemplateProviders.CompiledTemplateProvider.Tests/TemplateWrapperTests.cs
+++ b/src/TemplateProviders.CompiledTemplateProvider.Tests/TemplateWrapperTests.cs
@@ -85,16 +85,22 @@ public class TemplateWrapperTests
 
         private sealed class TemplateWithTypedParameters
         {
+#pragma warning disable S3459 // Unassigned members should be removed
             public string? Prop1 { get; set; }
             public string? Prop2 { get; set; }
+#pragma warning restore S3459 // Unassigned members should be removed
             public string? Skip1 { get; }
 #pragma warning disable S2376 // Write-only properties should not be used
-#pragma warning disable S3237 // "value" contextual keyword should be used
-#pragma warning disable S108 // Nested blocks of code should not be left empty
-            public string? Skip2 { set { } }
-#pragma warning restore S108 // Nested blocks of code should not be left empty
-#pragma warning restore S3237 // "value" contextual keyword should be used
+            public string? Skip2
 #pragma warning restore S2376 // Write-only properties should not be used
+            {
+#pragma warning disable S3237 // "value" contextual keyword should be used
+                set
+#pragma warning restore S3237 // "value" contextual keyword should be used
+                {
+                    // Left empty intentionally
+                }
+            }
         }
     }
 

--- a/src/TemplateProviders.CompiledTemplateProvider/TemplateWrapper.cs
+++ b/src/TemplateProviders.CompiledTemplateProvider/TemplateWrapper.cs
@@ -16,10 +16,14 @@ public class TemplateWrapper : ITemplateContextContainer, IParameterizedTemplate
 
     public ITemplateParameter[] GetParameters()
     {
-        var method = _instance.GetType().GetMethod(nameof(GetParameters));
+        var type = _instance.GetType();
+        var method = type.GetMethod(nameof(GetParameters));
         if (method is null)
         {
-            return Array.Empty<ITemplateParameter>();
+            return type.GetProperties()
+                .Where(p => p.CanRead && p.CanWrite)
+                .Select(p => new TemplateParameter(p.Name, p.PropertyType))
+                .ToArray();
         }
 
         var methodResult = method.Invoke(_instance, Array.Empty<object>());

--- a/src/TemplateProviders.FormattableStringTemplateProvider.Tests/FormattableStringTemplateTests.cs
+++ b/src/TemplateProviders.FormattableStringTemplateProvider.Tests/FormattableStringTemplateTests.cs
@@ -56,7 +56,7 @@ public class FormattableStringTemplateTests
         }
     }
 
-    public class Render : FormattableStringTemplateTests
+    public class Render_MultipleContentBuilder : FormattableStringTemplateTests
     {
         [Fact]
         public void Throws_On_Null_Builder()
@@ -65,7 +65,7 @@ public class FormattableStringTemplateTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.Render(builder: null!))
+            sut.Invoking(x => x.Render(builder: default(IMultipleContentBuilder)!))
                .Should().Throw<ArgumentNullException>().WithParameterName("builder");
         }
 

--- a/src/TemplateProviders.FormattableStringTemplateProvider.Tests/GlobalUsings.cs
+++ b/src/TemplateProviders.FormattableStringTemplateProvider.Tests/GlobalUsings.cs
@@ -1,1 +1,0 @@
-global using Xunit;

--- a/src/TemplateProviders.FormattableStringTemplateProvider.Tests/IntegrationTests.cs
+++ b/src/TemplateProviders.FormattableStringTemplateProvider.Tests/IntegrationTests.cs
@@ -14,7 +14,6 @@ public class IntegrationTests
         var templateProvider = provider.GetRequiredService<ITemplateProvider>();
         var template = templateProvider.Create(new CreateFormattableStringTemplateRequest("Hello {Name}!", CultureInfo.CurrentCulture));
         var templateEngine = provider.GetRequiredService<ITemplateEngine>();
-        var formattableStringParser = provider.GetRequiredService<IFormattableStringParser>();
         var builder = new StringBuilder();
         var request = new RenderTemplateRequest(template, builder, new { Name = "world" });
 

--- a/src/TemplateProviders.FormattableStringTemplateProvider.Tests/TemplateFramework.TemplateProviders.FormattableStringTemplateProvider.Tests.csproj
+++ b/src/TemplateProviders.FormattableStringTemplateProvider.Tests/TemplateFramework.TemplateProviders.FormattableStringTemplateProvider.Tests.csproj
@@ -32,6 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Using Include="CommunityToolkit.Diagnostics" />
     <Using Include="CrossCutting.Common.Results" />
     <Using Include="CrossCutting.Utilities.Parsers" />
     <Using Include="CrossCutting.Utilities.Parsers.Contracts" />

--- a/src/TemplateProviders.FormattableStringTemplateProvider.Tests/TestFormattableStringTemplate.cs
+++ b/src/TemplateProviders.FormattableStringTemplateProvider.Tests/TestFormattableStringTemplate.cs
@@ -1,0 +1,56 @@
+﻿namespace TemplateFramework.TemplateProviders.FormattableStringTemplateProvider.Tests;
+
+public class TestFormattableStringTemplate : IParameterizedTemplate, IStringBuilderTemplate
+{
+    private readonly Dictionary<string, object?> _parameterValues = new();
+
+    const string Template = @"        [Fact]
+        public void {UnittestName}()
+        {{
+            // Arrange
+            var sut = CreateSut();
+
+            // Act
+            var result = sut.{MethodName}();
+
+            // Assert
+            //TODO
+        }}";
+
+    public ITemplateParameter[] GetParameters()
+    {
+        using var provider = new ServiceCollection()
+            .AddParsers()
+            .AddTemplateFrameworkFormattableStringTemplateProvider()
+            .BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
+
+        var formattableStringParser = provider.GetRequiredService<IFormattableStringParser>();
+
+        return new FormattableStringTemplate(new CreateFormattableStringTemplateRequest(Template, CultureInfo.CurrentCulture), formattableStringParser).GetParameters();
+    }
+
+    public void Render(StringBuilder builder)
+    {
+        Guard.IsNotNull(builder);
+
+        using var provider = new ServiceCollection()
+            .AddParsers()
+            .AddTemplateFrameworkFormattableStringTemplateProvider()
+            .BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
+
+        var formattableStringParser = provider.GetRequiredService<IFormattableStringParser>();
+        var context = new TemplateFrameworkFormattableStringContext(_parameterValues);
+
+        builder.Append(formattableStringParser.Parse(Template, CultureInfo.CurrentCulture, context).GetValueOrThrow());
+    }
+
+    public void SetParameter(string name, object? value)
+    {
+        switch (name)
+        {
+            default:
+                _parameterValues.Add(name, value);
+                break;
+        }
+    }
+}

--- a/src/TemplateProviders.FormattableStringTemplateProvider/FormattableStringTemplate.cs
+++ b/src/TemplateProviders.FormattableStringTemplateProvider/FormattableStringTemplate.cs
@@ -1,6 +1,6 @@
 ﻿namespace TemplateFramework.TemplateProviders.FormattableStringTemplateProvider;
 
-public class FormattableStringTemplate : IParameterizedTemplate, IStringBuilderTemplate
+public class FormattableStringTemplate : IParameterizedTemplate, IStringBuilderTemplate, IMultipleContentBuilderTemplate, IDefaultFilenameContainer
 {
     private readonly CreateFormattableStringTemplateRequest _createFormattableStringTemplateRequest;
     private readonly IFormattableStringParser _formattableStringParser;
@@ -18,6 +18,8 @@ public class FormattableStringTemplate : IParameterizedTemplate, IStringBuilderT
 
         _parametersDictionary = new Dictionary<string, object?>();
     }
+
+    public string DefaultFilename { get; set; } = "";
 
     public ITemplateParameter[] GetParameters()
     {
@@ -38,6 +40,14 @@ public class FormattableStringTemplate : IParameterizedTemplate, IStringBuilderT
         var result = _formattableStringParser.Parse(_createFormattableStringTemplateRequest.Template, _createFormattableStringTemplateRequest.FormatProvider, context).GetValueOrThrow();
 
         builder.Append(result);
+    }
+
+    public void Render(IMultipleContentBuilder builder)
+    {
+        Guard.IsNotNull(builder);
+
+        // Convert single output to multiple output
+        this.RenderToMultipleContentBuilder(builder, DefaultFilename, false);
     }
 
     public void SetParameter(string name, object? value) => _parametersDictionary[name] = value;

--- a/src/TemplateProviders.FormattableStringTemplateProvider/Requests/CreateFormattableStringTemplateRequest.cs
+++ b/src/TemplateProviders.FormattableStringTemplateProvider/Requests/CreateFormattableStringTemplateRequest.cs
@@ -4,7 +4,7 @@ public sealed class CreateFormattableStringTemplateRequest : ICreateTemplateRequ
 {
     public CreateFormattableStringTemplateRequest(string template, IFormatProvider formatProvider)
     {
-        Guard.IsNotNullOrEmpty(template);
+        Guard.IsNotNull(template);
         Guard.IsNotNull(formatProvider);
 
         Template = template;

--- a/src/TemplateProviders.FormattableStringTemplateProvider/TemplateFramework.TemplateProviders.FormattableStringTemplateProvider.csproj
+++ b/src/TemplateProviders.FormattableStringTemplateProvider/TemplateFramework.TemplateProviders.FormattableStringTemplateProvider.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Core\TemplateFramework.Core.csproj" />
+    <ProjectReference Include="..\TemplateProviders.CompiledTemplateProvider.Tests\TemplateFramework.TemplateProviders.CompiledTemplateProvider.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TemplateProviders.FormattableStringTemplateProvider/TemplateFramework.TemplateProviders.FormattableStringTemplateProvider.csproj
+++ b/src/TemplateProviders.FormattableStringTemplateProvider/TemplateFramework.TemplateProviders.FormattableStringTemplateProvider.csproj
@@ -38,6 +38,7 @@
     <Using Include="TemplateFramework.Abstractions" />
     <Using Include="TemplateFramework.Abstractions.Templates" />
     <Using Include="TemplateFramework.Core" />
+    <Using Include="TemplateFramework.Core.Extensions" />
     <Using Include="TemplateFramework.TemplateProviders.FormattableStringTemplateProvider.Requests" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Added work-around for working with the root TemplateContext from a template assembly. The default filename can be injected from the template engine. Other stuff like the template engine and the template provider can only be injected using dependency injection, which means you have to reference Core and other packages, and then build your own DI provider and retrieve the root template from that provider.
- Added support for typed parameters on compiled templates. No need for creating switch on SetParameter, just implement the parameters strongly-typed
- Added support for extracting parameters from a template instance
- Added extension method for rendering multiple contents to a single content environment (in other wordt, to a StringBuilder)
- This PR includes some missing unit tests, and some other minor improvements