### PR TITLE
More refactoring

### DIFF
--- a/src/Abstractions/ITemplateComponentRegistry.cs
+++ b/src/Abstractions/ITemplateComponentRegistry.cs
@@ -1,0 +1,6 @@
+﻿namespace TemplateFramework.Abstractions;
+
+public interface ITemplateComponentRegistry
+{
+    void RegisterComponent(ITemplateProviderComponent component);
+}

--- a/src/Abstractions/ITemplateContext.cs
+++ b/src/Abstractions/ITemplateContext.cs
@@ -6,7 +6,7 @@ public interface ITemplateContext : IChildTemplateContext
     ITemplateContext? ParentContext { get; }
     ITemplateContext RootContext { get; }
     ITemplateEngine Engine { get; }
-    ITemplateProvider Provider { get; }
+    ITemplateComponentRegistry TemplateComponentRegistry { get; }
     string DefaultFilename { get; }
     bool IsRootContext { get; }
     bool HasIterations { get; }

--- a/src/Abstractions/ITemplateProvider.cs
+++ b/src/Abstractions/ITemplateProvider.cs
@@ -1,8 +1,7 @@
 ﻿namespace TemplateFramework.Abstractions;
 
-public interface ITemplateProvider
+public interface ITemplateProvider : ITemplateComponentRegistry
 {
     object Create(ITemplateIdentifier identifier);
-    void RegisterComponent(ITemplateProviderComponent component);
     void StartSession();
 }

--- a/src/Abstractions/ITemplateProviderPlugin.cs
+++ b/src/Abstractions/ITemplateProviderPlugin.cs
@@ -2,5 +2,5 @@
 
 public interface ITemplateProviderPlugin
 {
-    void Initialize(ITemplateProvider provider);
+    void Initialize(ITemplateComponentRegistry registry);
 }

--- a/src/Core.CodeGeneration.Tests/CodeGenerationEngine/CodeGenerationEngineTests.Generate.cs
+++ b/src/Core.CodeGeneration.Tests/CodeGenerationEngine/CodeGenerationEngineTests.Generate.cs
@@ -121,11 +121,11 @@ public partial class CodeGenerationEngineTests
             public Type GetGeneratorType() => typeof(object);
             public object? CreateModel() => null;
 
-            private readonly Action<ITemplateProvider> _action;
+            private readonly Action<ITemplateComponentRegistry> _action;
 
-            public MyPluginCodeGenerationProvider(Action<ITemplateProvider> action) => _action = action;
+            public MyPluginCodeGenerationProvider(Action<ITemplateComponentRegistry> action) => _action = action;
 
-            public void Initialize(ITemplateProvider provider) => _action(provider);
+            public void Initialize(ITemplateComponentRegistry registry) => _action(registry);
         }
     }
 }

--- a/src/Core.Tests/Extensions/TemplateEngineExtensions/TemplateEngineExtensionsTests.RenderChildTemplate.cs
+++ b/src/Core.Tests/Extensions/TemplateEngineExtensions/TemplateEngineExtensionsTests.RenderChildTemplate.cs
@@ -233,7 +233,7 @@ public partial class TemplateEngineExtensionsTests
         {
             // Arrange
             ContextMock.SetupGet(x => x.DefaultFilename).Returns(DefaultFilename);
-            ContextMock.SetupGet(x => x.Provider).Returns(TemplateProviderMock.Object);
+            ContextMock.SetupGet(x => x.TemplateComponentRegistry).Returns(TemplateProviderMock.Object);
             ContextMock.Setup(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>())).Returns(ContextMock.Object);
             TemplateProviderMock.Setup(x => x.Create(It.IsAny<ITemplateIdentifier>())).Returns(Template);
 
@@ -271,7 +271,7 @@ public partial class TemplateEngineExtensionsTests
         {
             // Arrange
             ContextMock.SetupGet(x => x.DefaultFilename).Returns(DefaultFilename);
-            ContextMock.SetupGet(x => x.Provider).Returns(TemplateProviderMock.Object);
+            ContextMock.SetupGet(x => x.TemplateComponentRegistry).Returns(TemplateProviderMock.Object);
             ContextMock.Setup(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>())).Returns(ContextMock.Object);
             TemplateProviderMock.Setup(x => x.Create(It.IsAny<ITemplateIdentifier>())).Returns(Template);
 

--- a/src/Core.Tests/Extensions/TemplateEngineExtensions/TemplateEngineExtensionsTests.RenderChildTemplates.cs
+++ b/src/Core.Tests/Extensions/TemplateEngineExtensions/TemplateEngineExtensionsTests.RenderChildTemplates.cs
@@ -154,7 +154,7 @@ public partial class TemplateEngineExtensionsTests
             // Arrange
             ContextMock.Setup(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>())).Returns(ContextMock.Object);
             ContextMock.SetupGet(x => x.DefaultFilename).Returns(DefaultFilename);
-            ContextMock.SetupGet(x => x.Provider).Returns(TemplateProviderMock.Object);
+            ContextMock.SetupGet(x => x.TemplateComponentRegistry).Returns(TemplateProviderMock.Object);
             TemplateProviderMock.Setup(x => x.Create(It.IsAny<ITemplateIdentifier>())).Returns(Template);
 
             // Act

--- a/src/Core.Tests/TemplateContext/TemplateContextTests.Constructor.cs
+++ b/src/Core.Tests/TemplateContext/TemplateContextTests.Constructor.cs
@@ -12,10 +12,10 @@ public partial class TemplateContextTests
         }
 
         [Fact]
-        public void Throws_On_Null_Provider()
+        public void Throws_On_Null_TemplateComponentRegistry()
         {
-            this.Invoking(_ => new TemplateContext(EngineMock.Object, provider: null!, DefaultFilename, new TemplateInstanceIdentifier(this), this))
-                .Should().Throw<ArgumentNullException>().WithParameterName("provider");
+            this.Invoking(_ => new TemplateContext(EngineMock.Object, templateComponentRegistry: null!, DefaultFilename, new TemplateInstanceIdentifier(this), this))
+                .Should().Throw<ArgumentNullException>().WithParameterName("templateComponentRegistry");
         }
 
         [Fact]

--- a/src/Core.Tests/TemplateContext/TemplateContextTests.CreateChildContext.cs
+++ b/src/Core.Tests/TemplateContext/TemplateContextTests.CreateChildContext.cs
@@ -28,7 +28,7 @@ public partial class TemplateContextTests
             // Assert
             childContext.Should().NotBeNull();
             childContext.IsRootContext.Should().BeFalse();
-            childContext.Template.Should().BeOfType<TemplateInstanceIdentifier>().And.Match<TemplateInstanceIdentifier>(x => x.Instance == template);
+            childContext.Template.Should().BeOfType<IgnoreThis>();
             childContext.ParentContext.Should().BeSameAs(sut);
         }
     }

--- a/src/Core.Tests/TemplateEngineContextTests.cs
+++ b/src/Core.Tests/TemplateEngineContextTests.cs
@@ -1,0 +1,75 @@
+﻿namespace TemplateFramework.Core.Tests;
+
+public class TemplateEngineContextTests
+{
+    protected Mock<IRenderTemplateRequest> RequestMock { get; } = new();
+    protected Mock<ITemplateEngine> EngineMock { get; } = new();
+    protected Mock<ITemplateComponentRegistry> ComponentRegistryMock { get; } = new();
+    protected object Template { get; } = new();
+
+    public class Constructor : TemplateEngineContextTests
+    {
+        [Fact]
+        public void Should_Throw_On_Null_Request()
+        {
+            // Act & Assert
+            this.Invoking(_ => new TemplateEngineContext(request: null!, EngineMock.Object, ComponentRegistryMock.Object, Template))
+                .Should().Throw<ArgumentNullException>().WithParameterName("request");
+        }
+
+        [Fact]
+        public void Should_Throw_On_Null_Engine()
+        {
+            // Act & Assert
+            this.Invoking(_ => new TemplateEngineContext(RequestMock.Object, engine: null!, ComponentRegistryMock.Object, Template))
+                .Should().Throw<ArgumentNullException>().WithParameterName("engine");
+        }
+
+        [Fact]
+        public void Should_Throw_On_Null_ComponentRegistry()
+        {
+            // Act & Assert
+            this.Invoking(_ => new TemplateEngineContext(RequestMock.Object, EngineMock.Object, componentRegistry: null!, Template))
+                .Should().Throw<ArgumentNullException>().WithParameterName("componentRegistry");
+        }
+
+        [Fact]
+        public void Should_Throw_On_Null_Template()
+        {
+            // Act & Assert
+            this.Invoking(_ => new TemplateEngineContext(RequestMock.Object, EngineMock.Object, ComponentRegistryMock.Object, template: null!))
+                .Should().Throw<ArgumentNullException>().WithParameterName("template");
+        }
+
+        [Fact]
+        public void Sets_Properties_Correctly()
+        {
+            // Arrange
+            var additionalParameters = new object();
+            var templateContextMock = new Mock<ITemplateContext>();
+            var generationEnvironmentMock = new Mock<IGenerationEnvironment>();
+            var identifierMock = new Mock<ITemplateIdentifier>();
+            var model = new object();
+            RequestMock.SetupGet(x => x.AdditionalParameters).Returns(additionalParameters);
+            RequestMock.SetupGet(x => x.Context).Returns(templateContextMock.Object);
+            RequestMock.SetupGet(x => x.DefaultFilename).Returns("Filename.txt");
+            RequestMock.SetupGet(x => x.GenerationEnvironment).Returns(generationEnvironmentMock.Object);
+            RequestMock.SetupGet(x => x.Identifier).Returns(identifierMock.Object);
+            RequestMock.SetupGet(x => x.Model).Returns(model);
+
+            // Act
+            var instance = new TemplateEngineContext(RequestMock.Object, EngineMock.Object, ComponentRegistryMock.Object, Template);
+
+            // Assert
+            instance.AdditionalParameters.Should().BeEquivalentTo(RequestMock.Object.AdditionalParameters);
+            instance.ComponentRegistry.Should().BeSameAs(ComponentRegistryMock.Object);
+            instance.Context.Should().BeSameAs(RequestMock.Object.Context);
+            instance.DefaultFilename.Should().BeSameAs(RequestMock.Object.DefaultFilename);
+            instance.Engine.Should().BeSameAs(EngineMock.Object);
+            instance.GenerationEnvironment.Should().BeSameAs(RequestMock.Object.GenerationEnvironment);
+            instance.Identifier.Should().BeSameAs(RequestMock.Object.Identifier);
+            instance.Model.Should().BeSameAs(RequestMock.Object.Model);
+            instance.Template.Should().BeSameAs(Template);
+        }
+    }
+}

--- a/src/Core.Tests/TemplateRenderers/MultipleContentTemplateRendererTests.Constructor.cs
+++ b/src/Core.Tests/TemplateRenderers/MultipleContentTemplateRendererTests.Constructor.cs
@@ -5,18 +5,10 @@ public partial class MultipleContentTemplateRendererTests
     public class Constructor : MultipleContentTemplateRendererTests
     {
         [Fact]
-        public void Throws_On_Null_SingleContentTemplateRenderer()
-        {
-            // Act & Assert
-            this.Invoking(_ => new MultipleContentTemplateRenderer(singleContentTemplateRenderer: null!, creators: Enumerable.Empty<IMultipleContentBuilderTemplateCreator>()))
-                .Should().Throw<ArgumentNullException>().WithParameterName("singleContentTemplateRenderer");
-        }
-
-        [Fact]
         public void Throws_On_Null_Creators()
         {
             // Act & Assert
-            this.Invoking(_ => new MultipleContentTemplateRenderer(SingleContentTemplateRendererMock.Object, creators: null!))
+            this.Invoking(_ => new MultipleContentTemplateRenderer(creators: null!))
                 .Should().Throw<ArgumentNullException>().WithParameterName("creators");
         }
     }

--- a/src/Core.Tests/TemplateRenderers/MultipleContentTemplateRendererTests.Render.cs
+++ b/src/Core.Tests/TemplateRenderers/MultipleContentTemplateRendererTests.Render.cs
@@ -4,13 +4,6 @@ public partial class MultipleContentTemplateRendererTests
 {
     public class Render : MultipleContentTemplateRendererTests
     {
-        public Render()
-        {
-            SingleContentTemplateRendererMock
-                .Setup(x => x.Render(It.IsAny<ITemplateEngineContext>()))
-                .Callback<ITemplateEngineContext>(req => ((StringBuilderEnvironment)req.GenerationEnvironment).Builder.Append(req.Template?.ToString()));
-        }
-
         [Fact]
         public void Throws_When_Context_Is_Null()
         {
@@ -55,7 +48,7 @@ public partial class MultipleContentTemplateRendererTests
         }
 
         [Fact]
-        public void Renders_To_MultipleContentBuilder_Correctly()
+        public void Renders_Non_MultipleContentBuilderTemplate_Correctly()
         {
             // Arrange
             var sut = CreateSut();
@@ -72,6 +65,7 @@ public partial class MultipleContentTemplateRendererTests
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), DefaultFilename, generationEnvironment.Object);
             var engineContext = new TemplateEngineContext(request, TemplateEngineMock.Object, TemplateProviderMock.Object, template);
             TemplateProviderMock.Setup(x => x.Create(It.IsAny<TemplateInstanceIdentifier>())).Returns(template);
+            TemplateEngineMock.Setup(x => x.Render(It.IsAny<IRenderTemplateRequest>())).Callback<IRenderTemplateRequest>(req => ((StringBuilderEnvironment)req.GenerationEnvironment).Builder.Append(template.ToString()));
 
             // Act
             sut.Render(engineContext);

--- a/src/Core.Tests/TemplateRenderers/MultipleContentTemplateRendererTests.cs
+++ b/src/Core.Tests/TemplateRenderers/MultipleContentTemplateRendererTests.cs
@@ -2,12 +2,11 @@
 
 public partial class MultipleContentTemplateRendererTests
 {
-    protected Mock<ISingleContentTemplateRenderer> SingleContentTemplateRendererMock { get; } = new();
     protected Mock<ITemplateProvider> TemplateProviderMock { get; } = new();
     protected Mock<IMultipleContentBuilderTemplateCreator> MultipleContentBuilderTemplateCreatorMock { get; } = new();
     protected Mock<ITemplateEngine> TemplateEngineMock { get; } = new();
 
-    protected MultipleContentTemplateRenderer CreateSut() => new(SingleContentTemplateRendererMock.Object, new[] { MultipleContentBuilderTemplateCreatorMock.Object });
+    protected MultipleContentTemplateRenderer CreateSut() => new(new[] { MultipleContentBuilderTemplateCreatorMock.Object });
 
     protected const string DefaultFilename = "MyFile.txt";
 }

--- a/src/Core.Tests/TestData.cs
+++ b/src/Core.Tests/TestData.cs
@@ -19,7 +19,7 @@ public sealed class PlainTemplateWithAdditionalParameters : IParameterizedTempla
 
 public sealed class TestTemplateProviderPlugin : ITemplateProviderPlugin
 {
-    public void Initialize(ITemplateProvider provider)
+    public void Initialize(ITemplateComponentRegistry registry)
     {
     }
 }

--- a/src/Core/Abstractions/IIgnoreThis.cs
+++ b/src/Core/Abstractions/IIgnoreThis.cs
@@ -1,0 +1,5 @@
+﻿namespace TemplateFramework.Core.Abstractions;
+
+internal interface IIgnoreThis
+{
+}

--- a/src/Core/Abstractions/ITemplateEngineContext.cs
+++ b/src/Core/Abstractions/ITemplateEngineContext.cs
@@ -3,6 +3,6 @@
 public interface ITemplateEngineContext : IRenderTemplateRequest
 {
     ITemplateEngine Engine { get; }
-    ITemplateProvider Provider { get; }
+    ITemplateComponentRegistry ComponentRegistry { get; }
     object? Template { get; }
 }

--- a/src/Core/IgnoreThis.cs
+++ b/src/Core/IgnoreThis.cs
@@ -1,5 +1,5 @@
 ﻿namespace TemplateFramework.Core;
 
-internal class IgnoreThis
+internal sealed class IgnoreThis : IIgnoreThis
 {
 }

--- a/src/Core/IgnoreThis.cs
+++ b/src/Core/IgnoreThis.cs
@@ -1,0 +1,5 @@
+﻿namespace TemplateFramework.Core;
+
+internal class IgnoreThis
+{
+}

--- a/src/Core/TemplateContext.cs
+++ b/src/Core/TemplateContext.cs
@@ -137,7 +137,7 @@ public sealed class TemplateContext : ITemplateContext
             templateComponentRegistry: TemplateComponentRegistry,
             defaultFilename: DefaultFilename,
             identifier: childContext.Identifier,
-            template: childContext.Identifier,
+            template: new IgnoreThis(),
             model: childContext.Model,
             parentContext: this,
             iterationNumber: childContext.IterationNumber,

--- a/src/Core/TemplateContext.cs
+++ b/src/Core/TemplateContext.cs
@@ -3,48 +3,48 @@
 public sealed class TemplateContext : ITemplateContext
 {
     public TemplateContext(ITemplateEngine engine,
-                           ITemplateProvider provider,
+                           ITemplateComponentRegistry templateComponentRegistry,
                            string defaultFilename,
                            ITemplateIdentifier identifier,
                            object template)
-        : this(engine, provider, defaultFilename, identifier, template, null, null, null, null)
+        : this(engine, templateComponentRegistry, defaultFilename, identifier, template, null, null, null, null)
     {
     }
 
     public TemplateContext(ITemplateEngine engine,
-                           ITemplateProvider provider,
+                           ITemplateComponentRegistry templateComponentRegistry,
                            string defaultFilename,
                            ITemplateIdentifier identifier,
                            object template,
                            ITemplateContext parentContext)
-        : this(engine, provider, defaultFilename, identifier, template, null, parentContext, null, null)
+        : this(engine, templateComponentRegistry, defaultFilename, identifier, template, null, parentContext, null, null)
     {
     }
 
     public TemplateContext(ITemplateEngine engine,
-                           ITemplateProvider provider,
+                           ITemplateComponentRegistry templateComponentRegistry,
                            string defaultFilename,
                            ITemplateIdentifier identifier,
                            object template,
                            object? model)
-        : this(engine, provider, defaultFilename, identifier, template, model, null, null, null)
+        : this(engine, templateComponentRegistry, defaultFilename, identifier, template, model, null, null, null)
     {
     }
 
     public TemplateContext(ITemplateEngine engine,
-                           ITemplateProvider provider,
+                           ITemplateComponentRegistry templateComponentRegistry,
                            string defaultFilename,
                            ITemplateIdentifier identifier,
                            object template,
                            object? model,
                            ITemplateContext parentContext)
-        : this(engine, provider, defaultFilename, identifier, template, model, parentContext, null, null)
+        : this(engine, templateComponentRegistry, defaultFilename, identifier, template, model, parentContext, null, null)
     {
     }
 
 #pragma warning disable S107
     public TemplateContext(ITemplateEngine engine,
-                           ITemplateProvider provider,
+                           ITemplateComponentRegistry templateComponentRegistry,
                            string defaultFilename,
                            ITemplateIdentifier identifier,
                            object template,
@@ -55,13 +55,13 @@ public sealed class TemplateContext : ITemplateContext
 #pragma warning restore S107
     {
         Guard.IsNotNull(engine);
-        Guard.IsNotNull(provider);
+        Guard.IsNotNull(templateComponentRegistry);
         Guard.IsNotNull(defaultFilename);
         Guard.IsNotNull(identifier);
         Guard.IsNotNull(template);
 
         Engine = engine;
-        Provider = provider;
+        TemplateComponentRegistry = templateComponentRegistry;
         DefaultFilename = defaultFilename;
         Identifier = identifier;
         Template = template;
@@ -76,7 +76,7 @@ public sealed class TemplateContext : ITemplateContext
     public object? Model { get; }
     public ITemplateContext? ParentContext { get; }
     public ITemplateEngine Engine { get; }
-    public ITemplateProvider Provider { get; }
+    public ITemplateComponentRegistry TemplateComponentRegistry { get; }
     public string DefaultFilename { get; }
 
     public ITemplateContext RootContext
@@ -134,7 +134,7 @@ public sealed class TemplateContext : ITemplateContext
         return new TemplateContext
         (
             engine: Engine,
-            provider: Provider,
+            templateComponentRegistry: TemplateComponentRegistry,
             defaultFilename: DefaultFilename,
             identifier: childContext.Identifier,
             template: childContext.Identifier,

--- a/src/Core/TemplateEngine.cs
+++ b/src/Core/TemplateEngine.cs
@@ -36,7 +36,7 @@ public sealed class TemplateEngine : ITemplateEngine
         Guard.IsNotNull(request);
 
         var template = request.Context?.Template;
-        if (template is null || template is IgnoreThis)
+        if (template is null || template is IIgnoreThis)
         {
             template = _provider.Create(request.Identifier);
         }

--- a/src/Core/TemplateEngine.cs
+++ b/src/Core/TemplateEngine.cs
@@ -35,14 +35,20 @@ public sealed class TemplateEngine : ITemplateEngine
     {
         Guard.IsNotNull(request);
 
-        var engineContext = new TemplateEngineContext(request, this, _provider, _provider.Create(request.Identifier));
+        var template = request.Context?.Template;
+        if (template is null || template is IgnoreThis)
+        {
+            template = _provider.Create(request.Identifier);
+        }
+
+        var engineContext = new TemplateEngineContext(request, this, _provider, template);
         
         _initializer.Initialize(engineContext);
 
         var renderer = _renderers.FirstOrDefault(x => x.Supports(request.GenerationEnvironment));
         if (renderer is null)
         {
-            throw new NotSupportedException($"Type of GenerationEnvironment ({request.GenerationEnvironment?.GetType().FullName}) is not supported");
+            throw new NotSupportedException($"Type of GenerationEnvironment ({request.GenerationEnvironment.GetType().FullName}) is not supported");
         }
 
         renderer.Render(engineContext);

--- a/src/Core/TemplateEngineContext.cs
+++ b/src/Core/TemplateEngineContext.cs
@@ -10,13 +10,13 @@ public class TemplateEngineContext : ITemplateEngineContext
     public ITemplateContext? Context { get; }
     public object? Template { get; }
     public ITemplateEngine Engine { get; }
-    public ITemplateProvider Provider { get; }
+    public ITemplateComponentRegistry ComponentRegistry { get; }
 
-    public TemplateEngineContext(IRenderTemplateRequest request, ITemplateEngine engine, ITemplateProvider provider, object template)
+    public TemplateEngineContext(IRenderTemplateRequest request, ITemplateEngine engine, ITemplateComponentRegistry componentRegistry, object template)
     {
         Guard.IsNotNull(request);
         Guard.IsNotNull(engine);
-        Guard.IsNotNull(provider);
+        Guard.IsNotNull(componentRegistry);
         Guard.IsNotNull(template);
 
         Identifier = request.Identifier;
@@ -26,7 +26,7 @@ public class TemplateEngineContext : ITemplateEngineContext
         AdditionalParameters = request.AdditionalParameters;
         Context = request.Context;
         Engine = engine;
-        Provider = provider;
+        ComponentRegistry = componentRegistry;
         Template = template;
     }
 }

--- a/src/Core/TemplateInitializerComponents/ContextInitializerComponent.cs
+++ b/src/Core/TemplateInitializerComponents/ContextInitializerComponent.cs
@@ -12,7 +12,7 @@ public class ContextInitializerComponent : ITemplateInitializerComponent
         }
 
         var templateContext = context.Context
-            ?? new TemplateContext(context.Engine, context.Provider, context.DefaultFilename, context.Identifier, context.Template!, context.Model);
+            ?? new TemplateContext(context.Engine, context.ComponentRegistry, context.DefaultFilename, context.Identifier, context.Template!, context.Model);
 
         templateContextContainer.Context = templateContext;
     }

--- a/src/Core/TemplateInitializerComponents/ProviderPluginInitializerComponent.cs
+++ b/src/Core/TemplateInitializerComponents/ProviderPluginInitializerComponent.cs
@@ -22,7 +22,7 @@ public class ProviderPluginInitializerComponent : ITemplateInitializerComponent
         
         if (context.Template is ITemplateProviderPlugin providerPlugin)
         {
-            providerPlugin.Initialize(context.Context.Provider);
+            providerPlugin.Initialize(context.Context.TemplateComponentRegistry);
         }
 
         if (context.Identifier is ITemplateProviderPluginIdentifier pluginIdentifier
@@ -31,7 +31,7 @@ public class ProviderPluginInitializerComponent : ITemplateInitializerComponent
         {
             var identifierPlugin = _factory.Create(pluginIdentifier.TemplateProviderAssemblyName, pluginIdentifier.TemplateProviderClassName, pluginIdentifier.CurrentDirectory);
             
-            identifierPlugin.Initialize(context.Context.Provider);
+            identifierPlugin.Initialize(context.Context.TemplateComponentRegistry);
         }
     }
 }

--- a/src/Core/TemplateRenderers/MultipleContentTemplateRenderer.cs
+++ b/src/Core/TemplateRenderers/MultipleContentTemplateRenderer.cs
@@ -2,17 +2,13 @@
 
 public sealed class MultipleContentTemplateRenderer : ITemplateRenderer
 {
-    private readonly ISingleContentTemplateRenderer _singleContentTemplateRenderer;
     private readonly IEnumerable<IMultipleContentBuilderTemplateCreator> _creators;
 
     public MultipleContentTemplateRenderer(
-        ISingleContentTemplateRenderer singleContentTemplateRenderer,
         IEnumerable<IMultipleContentBuilderTemplateCreator> creators)
     {
-        Guard.IsNotNull(singleContentTemplateRenderer);
         Guard.IsNotNull(creators);
 
-        _singleContentTemplateRenderer = singleContentTemplateRenderer;
         _creators = creators;
     }
 
@@ -43,8 +39,8 @@ public sealed class MultipleContentTemplateRenderer : ITemplateRenderer
         // Render using a stringbuilder, then add it to multiple contents
         var stringBuilder = new StringBuilder();
         var singleRequest = new RenderTemplateRequest(context.Identifier, context.Model, stringBuilder, context.DefaultFilename, context.AdditionalParameters, context.Context);
-        var template = context.Provider.Create(context.Identifier);
-        _singleContentTemplateRenderer.Render(new TemplateEngineContext(singleRequest, context.Engine, context.Provider, template));
+        context.Engine.Render(singleRequest);
+
         multipleContentBuilder.AddContent(context.DefaultFilename, false, new StringBuilder(stringBuilder.ToString()));
     }
 

--- a/src/Core/TemplateRenderers/StringBuilderTemplateRenderer.cs
+++ b/src/Core/TemplateRenderers/StringBuilderTemplateRenderer.cs
@@ -21,7 +21,7 @@ public sealed class StringBuilderTemplateRenderer : ISingleContentTemplateRender
         var environment = context.GenerationEnvironment as StringBuilderEnvironment;
         if (environment is null)
         {
-            throw new NotSupportedException($"Type of GenerationEnvironment ({context.GenerationEnvironment?.GetType().FullName}) is not supported");
+            throw new NotSupportedException($"Type of GenerationEnvironment ({context.GenerationEnvironment.GetType().FullName}) is not supported");
         }
 
         if (!_renderers.Any(x => x.TryRender(context.Template, environment.Builder)))

--- a/src/TemplateProviders.ChildTemplateProvider.Tests/IntegrationTests.cs
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/IntegrationTests.cs
@@ -16,8 +16,8 @@ public class IntegrationTests
 
         var template = new TestData.MultipleContentBuilderTemplateWithTemplateContextAndTemplateEngine((builder, context) =>
         {
-            var childTemplate = context.Provider.Create(new TemplateByNameIdentifier("MyTemplate"));
-            context.Engine.Render(new RenderTemplateRequest(new TemplateInstanceIdentifier(childTemplate), builder, context.CreateChildContext(new ChildTemplateContext(new TemplateInstanceIdentifier(childTemplate)))));
+            var identifier = new TemplateByNameIdentifier("MyTemplate");
+            context.Engine.RenderChildTemplate(new MultipleContentBuilderEnvironment(builder), identifier, context);
         });
         var generationEnvironment = new MultipleContentBuilder();
 

--- a/src/TemplateProviders.ChildTemplateProvider.Tests/TestData.cs
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/TestData.cs
@@ -375,9 +375,9 @@ public sealed class CsharpClassGeneratorCodeGenerationProvider : ICodeGeneration
         return viewModel;
     }
 
-    public void Initialize(ITemplateProvider provider)
+    public void Initialize(ITemplateComponentRegistry registry)
     {
-        Guard.IsNotNull(provider);
+        Guard.IsNotNull(registry);
 
         var registrations = new List<ITemplateCreator>
         {
@@ -386,6 +386,6 @@ public sealed class CsharpClassGeneratorCodeGenerationProvider : ICodeGeneration
             new TemplateCreator<TestData.ClassTemplate>(typeof(TestData.TypeBase))
         };
 
-        provider.RegisterComponent(new ProviderComponent(registrations));
+        registry.RegisterComponent(new ProviderComponent(registrations));
     }
 }


### PR DESCRIPTION
Refactor: Split RegisterComponent method of ITemplateProvider into ITemplateComponentRegistry, to separate concerns. A template provider can now just create a new template, while registration of child templates is performed in a separate interface.