### PR TITLE
CrossCutting package upgrade

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -37,7 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          dotnet-sonarscanner begin /k:"pauldeen79_TemplateFramework" /n:"TemplateFramework" /o:"pauldeen79" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml" -d:sonar.cs.vstest.reportsPaths="**/TestResults/*.trx /d:sonar.verbose=true"
+          dotnet-sonarscanner begin /k:"pauldeen79_TemplateFramework" /n:"TemplateFramework" /o:"pauldeen79" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml" -d:sonar.cs.vstest.reportsPaths="**/TestResults/*.trx"
           dotnet build
           dotnet test --logger trx --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
           dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -37,7 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          dotnet-sonarscanner begin /k:"pauldeen79_TemplateFramework" /n:"TemplateFramework" /o:"pauldeen79" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml" -d:sonar.cs.vstest.reportsPaths="**/TestResults/*.trx"
+          dotnet-sonarscanner begin /k:"pauldeen79_TemplateFramework" /n:"TemplateFramework" /o:"pauldeen79" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml" -d:sonar.cs.vstest.reportsPaths="**/TestResults/*.trx /d:sonar.verbose=true"
           dotnet build
           dotnet test --logger trx --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
           dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ Note that the following assemblies will be loaded from the host (Console) comman
 - TemplateFramework.TemplateProviders.ChildTemplateProvider
 - TemplateFramework.TemplateProviders.CompiledTemplateProvider
 - TemplateFramework.TemplateProviders.StringTemplateProvider
-- CrossCutting.Common (2.7.59)
-- CrossCutting.Utilities.Parsers (2.7.59)
+- CrossCutting.Common (2.8.0)
+- CrossCutting.Utilities.Parsers (2.8.0)
 - Microsoft.Extensions.DependencyInjection (7.0.0)
 - Microsoft.Extensions.DependencyInjection.Abstractions (7.0.0)
 

--- a/src/Console.Tests/TemplateFramework.Console.Tests.csproj
+++ b/src/Console.Tests/TemplateFramework.Console.Tests.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="pauldeen79.CrossCutting.Common.Testing" Version="2.7.59" />
+    <PackageReference Include="pauldeen79.CrossCutting.Common.Testing" Version="2.8.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/TemplateProviders.StringTemplateProvider.Tests/ExpressionStringTemplateTests.cs
+++ b/src/TemplateProviders.StringTemplateProvider.Tests/ExpressionStringTemplateTests.cs
@@ -4,10 +4,11 @@ public class ExpressionStringTemplateTests
 {
     protected const string Template = "Hello {Name}!";
     protected Mock<IExpressionStringParser> ExpressionStringParserMock { get; } = new();
+    protected Mock<IFormattableStringParser> FormattableStringParserMock { get; } = new();
     protected ExpressionStringTemplateIdentifier Identifier { get; } = new ExpressionStringTemplateIdentifier(Template, CultureInfo.CurrentCulture);
     protected ComponentRegistrationContext ComponentRegistrationContext { get; } = new();
 
-    protected ExpressionStringTemplate CreateSut() => new(Identifier, ExpressionStringParserMock.Object, ComponentRegistrationContext);
+    protected ExpressionStringTemplate CreateSut() => new(Identifier, ExpressionStringParserMock.Object, FormattableStringParserMock.Object, ComponentRegistrationContext);
 
     public class Constructor : ExpressionStringTemplateTests
     {
@@ -15,7 +16,7 @@ public class ExpressionStringTemplateTests
         public void Throws_On_Null_ExpressionStringTemplateIdentifier()
         {
             // Act & Assert
-            this.Invoking(_ => new ExpressionStringTemplate(expressionStringTemplateIdentifier: null!, ExpressionStringParserMock.Object, ComponentRegistrationContext))
+            this.Invoking(_ => new ExpressionStringTemplate(expressionStringTemplateIdentifier: null!, ExpressionStringParserMock.Object, FormattableStringParserMock.Object, ComponentRegistrationContext))
                 .Should().Throw<ArgumentNullException>().WithParameterName("expressionStringTemplateIdentifier");
         }
 
@@ -23,15 +24,23 @@ public class ExpressionStringTemplateTests
         public void Throws_On_Null_ExpressionStringParser()
         {
             // Act & Assert
-            this.Invoking(_ => new ExpressionStringTemplate(Identifier, expressionStringParser: null!, ComponentRegistrationContext))
+            this.Invoking(_ => new ExpressionStringTemplate(Identifier, expressionStringParser: null!, FormattableStringParserMock.Object, ComponentRegistrationContext))
                 .Should().Throw<ArgumentNullException>().WithParameterName("expressionStringParser");
+        }
+
+        [Fact]
+        public void Throws_On_Null_FormattableStringParser()
+        {
+            // Act & Assert
+            this.Invoking(_ => new ExpressionStringTemplate(Identifier, ExpressionStringParserMock.Object, formattableStringParser: null!, ComponentRegistrationContext))
+                .Should().Throw<ArgumentNullException>().WithParameterName("formattableStringParser");
         }
 
         [Fact]
         public void Throws_On_Null_ComponentRegistrationContext()
         {
             // Act & Assert
-            this.Invoking(_ => new ExpressionStringTemplate(Identifier, ExpressionStringParserMock.Object, componentRegistrationContext: null!))
+            this.Invoking(_ => new ExpressionStringTemplate(Identifier, ExpressionStringParserMock.Object, FormattableStringParserMock.Object, componentRegistrationContext: null!))
                 .Should().Throw<ArgumentNullException>().WithParameterName("componentRegistrationContext");
         }
     }
@@ -54,7 +63,7 @@ public class ExpressionStringTemplateTests
         {
             // Arrange
             ExpressionStringParserMock
-                .Setup(x => x.Parse(It.IsAny<string>(), It.IsAny<IFormatProvider>(), It.IsAny<TemplateFrameworkStringContext>()))
+                .Setup(x => x.Parse(It.IsAny<string>(), It.IsAny<IFormatProvider>(), It.IsAny<TemplateFrameworkStringContext>(), It.IsAny<IFormattableStringParser>()))
                 .Returns(Result<object?>.Error("Kaboom!"));
             var sut = CreateSut();
             var builder = new StringBuilder();
@@ -65,11 +74,11 @@ public class ExpressionStringTemplateTests
         }
 
         [Fact]
-        public void Appends_Result_From_FormattableStringParser_To_Builder_On_Succesful_Result()
+        public void Appends_Result_From_ExpressionStringParser_To_Builder_On_Succesful_Result()
         {
             // Arrange
             ExpressionStringParserMock
-                .Setup(x => x.Parse(It.IsAny<string>(), It.IsAny<IFormatProvider>(), It.IsAny<TemplateFrameworkStringContext>()))
+                .Setup(x => x.Parse(It.IsAny<string>(), It.IsAny<IFormatProvider>(), It.IsAny<TemplateFrameworkStringContext>(), It.IsAny<IFormattableStringParser>()))
                 .Returns(Result<object?>.Success("Parse result"));
             var sut = CreateSut();
             var builder = new StringBuilder();

--- a/src/TemplateProviders.StringTemplateProvider.Tests/IntegrationTests.cs
+++ b/src/TemplateProviders.StringTemplateProvider.Tests/IntegrationTests.cs
@@ -95,6 +95,39 @@ public class IntegrationTests
     }
 
     [Fact]
+    public void Can_Use_Expression_In_Placeholder()
+    {
+        // Arrange
+        var templateComponentRegistryPluginFactoryMock = new Mock<ITemplateComponentRegistryPluginFactory>();
+
+        var services = new ServiceCollection()
+            .AddParsers()
+            .AddTemplateFramework()
+            .AddTemplateFrameworkStringTemplateProvider()
+            .AddSingleton(templateComponentRegistryPluginFactoryMock.Object);
+
+        using var provider = services.BuildServiceProvider(true);
+        using var scope = provider.CreateScope();
+
+        var builder = new StringBuilder();
+        var templateEngine = scope.ServiceProvider.GetRequiredService<ITemplateEngine>();
+        var identifier = new FormattableStringTemplateIdentifier
+        (
+            "aaa {1 + 1} zzz",
+            CultureInfo.CurrentCulture
+        );
+        var template = scope.ServiceProvider.GetRequiredService<ITemplateProvider>().Create(identifier);
+        var context = new TemplateContext(templateEngine, scope.ServiceProvider.GetRequiredService<ITemplateProvider>(), "myfile.txt", identifier, template);
+        var request = new RenderTemplateRequest(identifier, builder, context);
+
+        // Act
+        templateEngine.Render(request);
+
+        // Assert
+        builder.ToString().Should().Be("aaa 2 zzz");
+    }
+
+    [Fact]
     public void Can_Use_Custom_Registered_FunctionResultParser()
     {
         // Arrange

--- a/src/TemplateProviders.StringTemplateProvider.Tests/IntegrationTests.cs
+++ b/src/TemplateProviders.StringTemplateProvider.Tests/IntegrationTests.cs
@@ -50,7 +50,7 @@ public class IntegrationTests
     }
 
     [Fact]
-    public void Can_Use_Custom_Registered_PlaceholderProcessor()
+    public void Can_Use_Custom_Registered_PlaceholderProcessor_In_FormattableStringTemplate()
     {
         // Arrange
         var templateComponentRegistryPluginFactoryMock = new Mock<ITemplateComponentRegistryPluginFactory>();
@@ -95,7 +95,7 @@ public class IntegrationTests
     }
 
     [Fact]
-    public void Can_Use_Expression_In_Placeholder()
+    public void Can_Use_Expression_In_Placeholder_In_FormattableStringTemplate()
     {
         // Arrange
         var templateComponentRegistryPluginFactoryMock = new Mock<ITemplateComponentRegistryPluginFactory>();
@@ -128,7 +128,52 @@ public class IntegrationTests
     }
 
     [Fact]
-    public void Can_Use_Custom_Registered_FunctionResultParser()
+    public void Can_Use_Custom_Registered_FunctionResultParser_In_FormattableStringTemplate()
+    {
+        // Arrange
+        var templateComponentRegistryPluginFactoryMock = new Mock<ITemplateComponentRegistryPluginFactory>();
+
+        var services = new ServiceCollection()
+            .AddParsers()
+            .AddTemplateFramework()
+            .AddTemplateFrameworkStringTemplateProvider()
+            .AddSingleton(templateComponentRegistryPluginFactoryMock.Object)
+            .AddScoped<ITemplateComponentRegistryPlugin, TestTemplateComponentRegistryPlugin>();
+
+        using var provider = services.BuildServiceProvider(true);
+        using var scope = provider.CreateScope();
+
+        templateComponentRegistryPluginFactoryMock
+            .Setup(x => x.Create(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns<string, string, string>((_, className, _)
+                => scope.ServiceProvider.GetServices<ITemplateComponentRegistryPlugin>()
+                    .OfType<TestTemplateComponentRegistryPlugin>()
+                    .FirstOrDefault(x => x.GetType().FullName == className)
+                        ?? throw new NotSupportedException($"Unsupported template component registry plug-in type: {className}"));
+
+        var builder = new StringBuilder();
+        var templateEngine = scope.ServiceProvider.GetRequiredService<ITemplateEngine>();
+        var identifier = new FormattableStringTemplateIdentifier
+        (
+            "aaa {MyFunction()} zzz",
+            CultureInfo.CurrentCulture,
+            typeof(TestTemplateComponentRegistryPlugin).Assembly.FullName,
+            typeof(TestTemplateComponentRegistryPlugin).FullName,
+            Directory.GetCurrentDirectory()
+        );
+        var template = scope.ServiceProvider.GetRequiredService<ITemplateProvider>().Create(identifier);
+        var context = new TemplateContext(templateEngine, scope.ServiceProvider.GetRequiredService<ITemplateProvider>(), "myfile.txt", identifier, template);
+        var request = new RenderTemplateRequest(identifier, builder, context);
+
+        // Act
+        templateEngine.Render(request);
+
+        // Assert
+        builder.ToString().Should().Be("aaa Hello world! zzz");
+    }
+
+    [Fact]
+    public void Can_Use_Custom_Registered_FunctionResultParser_In_ExpressionStringTemplate()
     {
         // Arrange
         var templateComponentRegistryPluginFactoryMock = new Mock<ITemplateComponentRegistryPluginFactory>();

--- a/src/TemplateProviders.StringTemplateProvider.Tests/ProviderComponentTests.cs
+++ b/src/TemplateProviders.StringTemplateProvider.Tests/ProviderComponentTests.cs
@@ -76,7 +76,6 @@ public class ProviderComponentTests
             result.Should().BeTrue();
         }
 
-
         [Fact]
         public void Returns_True_When_Request_Is_FormattableStringTemplateIdentifier()
         {
@@ -116,7 +115,7 @@ public class ProviderComponentTests
         }
         
         [Fact]
-        public void Returns_FormattableStringTemplate_On_Identifier_Of_Correct_Type()
+        public void Returns_ExpressionStringTemplate_On_Identifier_Of_Correct_Type()
         {
             // Arrange
             var sut = CreateSut();
@@ -127,6 +126,20 @@ public class ProviderComponentTests
 
             // Assert
             result.Should().BeOfType<ExpressionStringTemplate>();
+        }
+
+        [Fact]
+        public void Returns_FormattableStringTemplate_On_Identifier_Of_Correct_Type()
+        {
+            // Arrange
+            var sut = CreateSut();
+            var identifier = new FormattableStringTemplateIdentifier("template", CultureInfo.CurrentCulture);
+
+            // Act
+            var result = sut.Create(identifier);
+
+            // Assert
+            result.Should().BeOfType<FormattableStringTemplate>();
         }
     }
 

--- a/src/TemplateProviders.StringTemplateProvider.Tests/TemplateFramework.TemplateProviders.StringTemplateProvider.Tests.csproj
+++ b/src/TemplateProviders.StringTemplateProvider.Tests/TemplateFramework.TemplateProviders.StringTemplateProvider.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="pauldeen79.ExpressionFramework.Domain.Parser" Version="0.5.13" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -37,6 +38,7 @@
     <Using Include="CrossCutting.Utilities.Parsers" />
     <Using Include="CrossCutting.Utilities.Parsers.Contracts" />
     <Using Include="CrossCutting.Utilities.Parsers.Extensions" />
+    <Using Include="ExpressionFramework.Parser" />
     <Using Include="FluentAssertions" />
     <Using Include="Microsoft.Extensions.DependencyInjection" />
     <Using Include="Moq" />

--- a/src/TemplateProviders.StringTemplateProvider.Tests/TemplateFrameworkContextPlaceholderProcessorTests.cs
+++ b/src/TemplateProviders.StringTemplateProvider.Tests/TemplateFrameworkContextPlaceholderProcessorTests.cs
@@ -3,7 +3,8 @@
 public class TemplateFrameworkContextPlaceholderProcessorTests
 {
     protected ComponentRegistrationContext ComponentRegistrationContext { get; } = new();
-    
+    protected Mock<IFormattableStringParser> FormattableStringParserMock { get; } = new();
+
     protected TemplateFrameworkContextPlaceholderProcessor CreateSut() => new();
 
     public class Process : TemplateFrameworkContextPlaceholderProcessorTests
@@ -15,7 +16,7 @@ public class TemplateFrameworkContextPlaceholderProcessorTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.Process(value: null!, CultureInfo.CurrentCulture, null))
+            sut.Invoking(x => x.Process(value: null!, CultureInfo.CurrentCulture, null, FormattableStringParserMock.Object))
                .Should().Throw<ArgumentNullException>().WithParameterName("value");
         }
 
@@ -26,8 +27,19 @@ public class TemplateFrameworkContextPlaceholderProcessorTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.Process("some template", formatProvider: null!, null))
+            sut.Invoking(x => x.Process("some template", formatProvider: null!, null, FormattableStringParserMock.Object))
                .Should().Throw<ArgumentNullException>().WithParameterName("formatProvider");
+        }
+
+        [Fact]
+        public void Throws_On_Null_FormattableStringParser()
+        {
+            // Arrange
+            var sut = CreateSut();
+
+            // Act & Assert
+            sut.Invoking(x => x.Process("some template", CultureInfo.CurrentCulture, null, formattableStringParser: null!))
+               .Should().Throw<ArgumentNullException>().WithParameterName("formattableStringParser");
         }
 
         [Fact]
@@ -38,7 +50,7 @@ public class TemplateFrameworkContextPlaceholderProcessorTests
             var context = "some context that's not of type TemplateFrameworkFormattableStringContext";
 
             // Act
-            var result = sut.Process("some template", CultureInfo.CurrentCulture, context);
+            var result = sut.Process("some template", CultureInfo.CurrentCulture, context, FormattableStringParserMock.Object);
 
             // Assert
             result.Status.Should().Be(ResultStatus.Continue);
@@ -56,7 +68,7 @@ public class TemplateFrameworkContextPlaceholderProcessorTests
             var context = new TemplateFrameworkStringContext(parametersDictionary, ComponentRegistrationContext, false);
 
             // Act
-            var result = sut.Process("Name", CultureInfo.CurrentCulture, context);
+            var result = sut.Process("Name", CultureInfo.CurrentCulture, context, FormattableStringParserMock.Object);
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -75,7 +87,7 @@ public class TemplateFrameworkContextPlaceholderProcessorTests
             var context = new TemplateFrameworkStringContext(parametersDictionary, ComponentRegistrationContext, false);
 
             // Act
-            var result = sut.Process("Name", CultureInfo.CurrentCulture, context);
+            var result = sut.Process("Name", CultureInfo.CurrentCulture, context, FormattableStringParserMock.Object);
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -91,7 +103,7 @@ public class TemplateFrameworkContextPlaceholderProcessorTests
             var context = new TemplateFrameworkStringContext(parametersDictionary, ComponentRegistrationContext, false);
 
             // Act
-            var result = sut.Process("Name", CultureInfo.CurrentCulture, context);
+            var result = sut.Process("Name", CultureInfo.CurrentCulture, context, FormattableStringParserMock.Object);
 
             // Assert
             result.Status.Should().Be(ResultStatus.Continue);
@@ -106,7 +118,7 @@ public class TemplateFrameworkContextPlaceholderProcessorTests
             var context = new TemplateFrameworkStringContext(parametersDictionary, ComponentRegistrationContext, false);
 
             // Act
-            _ = sut.Process("Name", CultureInfo.CurrentCulture, context);
+            _ = sut.Process("Name", CultureInfo.CurrentCulture, context, FormattableStringParserMock.Object);
 
             // Assert
             context.ParameterNamesList.Should().BeEquivalentTo("Name");
@@ -121,7 +133,7 @@ public class TemplateFrameworkContextPlaceholderProcessorTests
             var context = new TemplateFrameworkStringContext(parametersDictionary, ComponentRegistrationContext, false);
 
             // Act
-            _ = sut.Process("__Name", CultureInfo.CurrentCulture, context);
+            _ = sut.Process("__Name", CultureInfo.CurrentCulture, context, FormattableStringParserMock.Object);
 
             // Assert
             context.ParameterNamesList.Should().BeEmpty();

--- a/src/TemplateProviders.StringTemplateProvider.Tests/TestTemplateComponentRegistryPlugin.cs
+++ b/src/TemplateProviders.StringTemplateProvider.Tests/TestTemplateComponentRegistryPlugin.cs
@@ -15,8 +15,8 @@ public sealed class TestTemplateComponentRegistryPlugin : ITemplateComponentRegi
     {
         var processorProcessorMock = new Mock<IPlaceholderProcessor>();
         processorProcessorMock
-            .Setup(x => x.Process(It.IsAny<string>(), It.IsAny<IFormatProvider>(), It.IsAny<object?>()))
-            .Returns<string, IFormatProvider, object?>((value, _, _) => value == "__test" ? Result<string>.Success("Hello world!") : Result<string>.Continue());
+            .Setup(x => x.Process(It.IsAny<string>(), It.IsAny<IFormatProvider>(), It.IsAny<object?>(), It.IsAny<IFormattableStringParser>()))
+            .Returns<string, IFormatProvider, object?, IFormattableStringParser>((value, _, _, _) => value == "__test" ? Result<string>.Success("Hello world!") : Result<string>.Continue());
 
         var functionResultParserMock = new Mock<IFunctionResultParser>();
         functionResultParserMock

--- a/src/TemplateProviders.StringTemplateProvider/ExpressionStringTemplate.cs
+++ b/src/TemplateProviders.StringTemplateProvider/ExpressionStringTemplate.cs
@@ -4,20 +4,24 @@ public class ExpressionStringTemplate : IStringBuilderTemplate
 {
     private readonly ExpressionStringTemplateIdentifier _expressionStringTemplateIdentifier;
     private readonly IExpressionStringParser _expressionStringParser;
+    private readonly IFormattableStringParser _formattableStringParser;
     private readonly ComponentRegistrationContext _componentRegistrationContext;
     private readonly IDictionary<string, object?> _parametersDictionary;
     
     public ExpressionStringTemplate(
         ExpressionStringTemplateIdentifier expressionStringTemplateIdentifier,
         IExpressionStringParser expressionStringParser,
+        IFormattableStringParser formattableStringParser,
         ComponentRegistrationContext componentRegistrationContext)
     {
         Guard.IsNotNull(expressionStringTemplateIdentifier);
         Guard.IsNotNull(expressionStringParser);
+        Guard.IsNotNull(formattableStringParser);
         Guard.IsNotNull(componentRegistrationContext);
 
         _expressionStringTemplateIdentifier = expressionStringTemplateIdentifier;
         _expressionStringParser = expressionStringParser;
+        _formattableStringParser = formattableStringParser;
         _componentRegistrationContext = componentRegistrationContext;
 
         _parametersDictionary = new Dictionary<string, object?>();
@@ -28,7 +32,7 @@ public class ExpressionStringTemplate : IStringBuilderTemplate
         Guard.IsNotNull(builder);
 
         var context = new TemplateFrameworkStringContext(_parametersDictionary, _componentRegistrationContext, false);
-        var result = _expressionStringParser.Parse(_expressionStringTemplateIdentifier.Template, _expressionStringTemplateIdentifier.FormatProvider, context).GetValueOrThrow();
+        var result = _expressionStringParser.Parse(_expressionStringTemplateIdentifier.Template, _expressionStringTemplateIdentifier.FormatProvider, context, _formattableStringParser).GetValueOrThrow();
 
         builder.Append(result);
     }

--- a/src/TemplateProviders.StringTemplateProvider/ProviderComponent.cs
+++ b/src/TemplateProviders.StringTemplateProvider/ProviderComponent.cs
@@ -25,7 +25,7 @@ public class ProviderComponent : ITemplateProviderComponent, ISessionAwareCompon
 
         if (identifier is ExpressionStringTemplateIdentifier expressionStringTemplateIdentifier)
         {
-            return new ExpressionStringTemplate(expressionStringTemplateIdentifier, _expressionStringParser, _componentRegistrationContext);
+            return new ExpressionStringTemplate(expressionStringTemplateIdentifier, _expressionStringParser, _formattableStringParser, _componentRegistrationContext);
         }
         else if (identifier is FormattableStringTemplateIdentifier formattableStringTemplateIdentifier)
         {

--- a/src/TemplateProviders.StringTemplateProvider/TemplateFramework.TemplateProviders.StringTemplateProvider.csproj
+++ b/src/TemplateProviders.StringTemplateProvider/TemplateFramework.TemplateProviders.StringTemplateProvider.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="pauldeen79.CrossCutting.Utilities.Parsers" Version="2.7.59" />
+    <PackageReference Include="pauldeen79.CrossCutting.Utilities.Parsers" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TemplateProviders.StringTemplateProvider/TemplateFrameworkContextPlaceholderProcessor.cs
+++ b/src/TemplateProviders.StringTemplateProvider/TemplateFrameworkContextPlaceholderProcessor.cs
@@ -4,10 +4,11 @@ public sealed class TemplateFrameworkContextPlaceholderProcessor : IPlaceholderP
 {
     public int Order => 100;
 
-    public Result<string> Process(string value, IFormatProvider formatProvider, object? context)
+    public Result<string> Process(string value, IFormatProvider formatProvider, object? context, IFormattableStringParser formattableStringParser)
     {
         Guard.IsNotNull(value);
         Guard.IsNotNull(formatProvider);
+        Guard.IsNotNull(formattableStringParser);
 
         if (context is not TemplateFrameworkStringContext templateFrameworkFormattableStringContext)
         {
@@ -16,7 +17,7 @@ public sealed class TemplateFrameworkContextPlaceholderProcessor : IPlaceholderP
 
         foreach (var placholderProcessor in templateFrameworkFormattableStringContext.Context.PlaceholderProcessors.OrderBy(x => Order))
         {
-            var result = placholderProcessor.Process(value, formatProvider, context);
+            var result = placholderProcessor.Process(value, formatProvider, context, formattableStringParser);
             if (result.IsSuccessful() && result.Status != ResultStatus.Continue)
             {
                 return result;


### PR DESCRIPTION
Upgraded CrossCutting.Common and CrossCutting.Utilities.Parsers to version 2.8.0 to support expressions in placeholders of FormattableString templates.

You can now use mathematic expressions (like 1+1), functions (like MyFunction()) and other stuff inside your formattable string templates.

So, something like:
I can compute 1+1, this results in {1+1}