### PR TITLE
Replace Moq with NSubstitute

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -141,6 +141,10 @@ dotnet_code_quality.CA1062.exclude_extension_method_this_parameter = true
 # SYSLIB1045 Use 'GeneratedRegexAttribute' to generate the regular expression implementation at compile-time.
 #dotnet_diagnostic.SYSLIB1045.severity = none
 
+[*Test*.cs]
+# Getting false positives on arguments possibly being null. They're injected using AutoFixture!
+dotnet_diagnostic.CA1062.severity = none
+
 ###############################
 # VB Coding Conventions       #
 ###############################

--- a/src/Abstractions.Tests/Extensions/MultipleContentBuilderExtensions/MultipleContentBuilderExtensionsTests.AddContent.cs
+++ b/src/Abstractions.Tests/Extensions/MultipleContentBuilderExtensions/MultipleContentBuilderExtensionsTests.AddContent.cs
@@ -11,10 +11,10 @@ public partial class MultipleContentBuilderExtensionsTests
             var sut = CreateSut();
 
             // Act
-            sut.Object.AddContent();
+            sut.AddContent();
 
             // Assert
-            sut.Verify(x => x.AddContent(string.Empty, false, null), Times.Once);
+            sut.Received().AddContent(string.Empty, false, null);
         }
 
         [Fact]
@@ -24,10 +24,10 @@ public partial class MultipleContentBuilderExtensionsTests
             var sut = CreateSut();
 
             // Act
-            sut.Object.AddContent("MyFilename.txt");
+            sut.AddContent("MyFilename.txt");
 
             // Assert
-            sut.Verify(x => x.AddContent("MyFilename.txt", false, null), Times.Once);
+            sut.Received().AddContent("MyFilename.txt", false, null);
         }
 
         [Fact]
@@ -37,10 +37,10 @@ public partial class MultipleContentBuilderExtensionsTests
             var sut = CreateSut();
 
             // Act
-            sut.Object.AddContent("MyFilename.txt", true);
+            sut.AddContent("MyFilename.txt", true);
 
             // Assert
-            sut.Verify(x => x.AddContent("MyFilename.txt", true, null), Times.Once);
+            sut.Received().AddContent("MyFilename.txt", true, null);
         }
     }
 }

--- a/src/Abstractions.Tests/Extensions/MultipleContentBuilderExtensions/MultipleContentBuilderExtensionsTests.cs
+++ b/src/Abstractions.Tests/Extensions/MultipleContentBuilderExtensions/MultipleContentBuilderExtensionsTests.cs
@@ -2,5 +2,5 @@
 
 public partial class MultipleContentBuilderExtensionsTests
 {
-    protected Mock<IMultipleContentBuilder> CreateSut() => new();
+    protected IMultipleContentBuilder CreateSut() => Substitute.For<IMultipleContentBuilder>();
 }

--- a/src/Abstractions.Tests/Extensions/TemplateContextExtensions/TemplateContextExtensionsTests.GetContextByTemplateType.cs
+++ b/src/Abstractions.Tests/Extensions/TemplateContextExtensions/TemplateContextExtensionsTests.GetContextByTemplateType.cs
@@ -11,10 +11,10 @@ public partial class TemplateContextExtensionsTests
             var sut = CreateSut();
 
             // Act
-            sut.Object.GetContextByTemplateType<string>();
+            sut.GetContextByTemplateType<string>();
 
             // Assert
-            sut.Verify(x => x.GetContextByTemplateType<string>(null), Times.Once);
+            sut.Received().GetContextByTemplateType<string>(null);
         }
     }
 }

--- a/src/Abstractions.Tests/Extensions/TemplateContextExtensions/TemplateContextExtensionsTests.GetModelFromContextByType.cs
+++ b/src/Abstractions.Tests/Extensions/TemplateContextExtensions/TemplateContextExtensionsTests.GetModelFromContextByType.cs
@@ -11,10 +11,10 @@ public partial class TemplateContextExtensionsTests
             var sut = CreateSut();
 
             // Act
-            sut.Object.GetModelFromContextByType<string>();
+            sut.GetModelFromContextByType<string>();
 
             // Assert
-            sut.Verify(x => x.GetModelFromContextByType<string>(null), Times.Once);
+            sut.Received().GetModelFromContextByType<string>(null);
         }
     }
 }

--- a/src/Abstractions.Tests/Extensions/TemplateContextExtensions/TemplateContextExtensionsTests.cs
+++ b/src/Abstractions.Tests/Extensions/TemplateContextExtensions/TemplateContextExtensionsTests.cs
@@ -1,8 +1,8 @@
-﻿namespace TemplateFramework.Abstractions.Tests.Extensions.TemplateContextExtensions;
+namespace TemplateFramework.Abstractions.Tests.Extensions.TemplateContextExtensions;
 
 public partial class TemplateContextExtensionsTests
 {
-    protected Mock<ITemplateContext> CreateSut() => new();
+    protected ITemplateContext CreateSut() => Substitute.For<ITemplateContext>();
     protected object Template { get; } = new();
     protected object Model { get; } = new();
     protected int? IterationNumber { get; } = 0;

--- a/src/Abstractions.Tests/TemplateFramework.Abstractions.Tests.csproj
+++ b/src/Abstractions.Tests/TemplateFramework.Abstractions.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="Moq" />
+    <Using Include="NSubstitute" />
     <Using Include="TemplateFramework.Abstractions.Extensions" />
     <Using Include="Xunit" />
   </ItemGroup>

--- a/src/Abstractions/TemplateFramework.Abstractions.csproj
+++ b/src/Abstractions/TemplateFramework.Abstractions.csproj
@@ -10,6 +10,9 @@
     <PackageTags>templateengine;codegeneration</PackageTags>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/pauldeen79/TemplateFramework</RepositoryUrl>
+    <!-- Used by code coverage -->
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Console.Tests/Commands/CodeGenerationAssemblyCommandTests.cs
+++ b/src/Console.Tests/Commands/CodeGenerationAssemblyCommandTests.cs
@@ -7,7 +7,7 @@ public class CodeGenerationAssemblyCommandTests
         [Fact]
         public void Throws_On_Null_Argument()
         {
-            TestHelpers.ConstructorMustThrowArgumentNullException(typeof(CodeGenerationAssemblyCommand), t => Substitute.For(new[] { t }, Array.Empty<object>()));
+            typeof(CodeGenerationAssemblyCommand).ShouldArgumentNullExceptionsInConstructorOnNullArguments();
         }
     }
 

--- a/src/Console.Tests/Commands/CodeGenerationAssemblyCommandTests.cs
+++ b/src/Console.Tests/Commands/CodeGenerationAssemblyCommandTests.cs
@@ -2,13 +2,6 @@
 
 public class CodeGenerationAssemblyCommandTests
 {
-    protected ICodeGenerationAssembly CodeGenerationAssemblyMock { get; } = Substitute.For<ICodeGenerationAssembly>();
-    protected IClipboard ClipboardMock { get; } = Substitute.For<IClipboard>();
-    protected IFileSystem FileSystemMock { get; } = Substitute.For<IFileSystem>();
-    protected IUserInput UserInputMock { get; } = Substitute.For<IUserInput>();
-
-    private CodeGenerationAssemblyCommand CreateSut() => new(ClipboardMock, FileSystemMock, UserInputMock, CodeGenerationAssemblyMock);
-
     public class Constructor
     {
         [Fact]
@@ -20,12 +13,11 @@ public class CodeGenerationAssemblyCommandTests
 
     public class Initialize : CodeGenerationAssemblyCommandTests
     {
-        [Fact]
-        public void Initialize_Adds_Command_To_Application()
+        [Theory, AutoMockData]
+        public void Initialize_Adds_Command_To_Application(CodeGenerationAssemblyCommand sut)
         {
             // Arrange
             using var app = new CommandLineApplication();
-            var sut = CreateSut();
 
             // Act
             sut.Initialize(app);
@@ -34,12 +26,9 @@ public class CodeGenerationAssemblyCommandTests
             app.Commands.Should().ContainSingle();
         }
 
-        [Fact]
-        public void Initialize_Throws_On_Null_Argument()
+        [Theory, AutoMockData]
+        public void Initialize_Throws_On_Null_Argument(CodeGenerationAssemblyCommand sut)
         {
-            // Arrange
-            var sut = CreateSut();
-
             // Act & Assert
             sut.Invoking(x => x.Initialize(app: null!))
                .Should().Throw<ArgumentNullException>().WithParameterName("app");
@@ -48,190 +37,215 @@ public class CodeGenerationAssemblyCommandTests
 
     public class ExecuteComand : CodeGenerationAssemblyCommandTests
     {
-        [Fact]
-        public void Empty_AssemblyName_Results_In_Error()
+        [Theory, AutoMockData]
+        public void Empty_AssemblyName_Results_In_Error(CodeGenerationAssemblyCommand sut)
         {
             // Act
-            var output = CommandLineCommandHelper.ExecuteCommand(CreateSut);
+            var output = CommandLineCommandHelper.ExecuteCommand(sut);
 
             // Assert
             output.Should().Be("Error: Assembly name is required." + Environment.NewLine);
         }
 
-        [Fact]
-        public void Uses_Current_Directory_As_CurrentDirectory_When_AssemblyName_Is_Not_A_Filename()
+        [Theory, AutoMockData]
+        public void Uses_Current_Directory_As_CurrentDirectory_When_AssemblyName_Is_Not_A_Filename(
+            [Frozen] ICodeGenerationAssembly codeGenerationAssemblyMock,
+            CodeGenerationAssemblyCommand sut)
         {
             // Act
-            _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}");
+            _ = CommandLineCommandHelper.ExecuteCommand(sut, $"--name {GetType().Assembly.FullName}");
 
             // Assert
-            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.CurrentDirectory == Directory.GetCurrentDirectory()), Arg.Any<IGenerationEnvironment>());
+            codeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.CurrentDirectory == Directory.GetCurrentDirectory()), Arg.Any<IGenerationEnvironment>());
         }
 
-        [Fact]
-        public void Uses_Directory_Of_Assembly_As_CurrentDirectory_When_AssemblyName_Is_Not_A_Filename()
+        [Theory, AutoMockData]
+        public void Uses_Directory_Of_Assembly_As_CurrentDirectory_When_AssemblyName_Is_Not_A_Filename(
+            [Frozen] ICodeGenerationAssembly codeGenerationAssemblyMock,
+            CodeGenerationAssemblyCommand sut)
         {
             // Act
-            _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {Path.Combine(TestData.BasePath, "myassembly.dll")}");
+            _ = CommandLineCommandHelper.ExecuteCommand(sut, $"--name {Path.Combine(TestData.BasePath, "myassembly.dll")}");
 
             // Assert
-            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.CurrentDirectory == TestData.BasePath), Arg.Any<IGenerationEnvironment>());
+            codeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.CurrentDirectory == TestData.BasePath), Arg.Any<IGenerationEnvironment>());
         }
 
-        [Fact]
-        public void Uses_Specified_CurrentDirectory_When_Available()
+        [Theory, AutoMockData]
+        public void Uses_Specified_CurrentDirectory_When_Available(
+            [Frozen] ICodeGenerationAssembly codeGenerationAssemblyMock, 
+            CodeGenerationAssemblyCommand sut)
         {
             // Act
-            _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {Path.Combine(TestData.BasePath, "myassembly.dll")}", "--directory something");
+            _ = CommandLineCommandHelper.ExecuteCommand(sut, $"--name {Path.Combine(TestData.BasePath, "myassembly.dll")}", "--directory something");
 
             // Assert
-            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.CurrentDirectory == "something"), Arg.Any<IGenerationEnvironment>());
+            codeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.CurrentDirectory == "something"), Arg.Any<IGenerationEnvironment>());
         }
 
-        [Fact]
-        public void Uses_Specified_BasePath_From_Arguments_When_Present()
+        [Theory, AutoMockData]
+        public void Uses_Specified_BasePath_From_Arguments_When_Present(
+            [Frozen] ICodeGenerationAssembly codeGenerationAssemblyMock, 
+            CodeGenerationAssemblyCommand sut)
         {
             // Act
-            _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}", $"--path {TestData.BasePath}");
+            _ = CommandLineCommandHelper.ExecuteCommand(sut, $"--name {GetType().Assembly.FullName}", $"--path {TestData.BasePath}");
 
             // Assert
-            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.BasePath == TestData.BasePath), Arg.Any<IGenerationEnvironment>());
+            codeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.BasePath == TestData.BasePath), Arg.Any<IGenerationEnvironment>());
         }
 
-        [Fact]
-        public void Uses_Empty_BasePath_When_Not_Present_In_Arguments()
+        [Theory, AutoMockData]
+        public void Uses_Empty_BasePath_When_Not_Present_In_Arguments(
+            [Frozen] ICodeGenerationAssembly codeGenerationAssemblyMock, 
+            CodeGenerationAssemblyCommand sut)
         {
             // Act
-            _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}");
+            _ = CommandLineCommandHelper.ExecuteCommand(sut, $"--name {GetType().Assembly.FullName}");
 
             // Assert
-            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.BasePath == string.Empty), Arg.Any<IGenerationEnvironment>());
+            codeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.BasePath == string.Empty), Arg.Any<IGenerationEnvironment>());
         }
 
-        [Fact]
-        public void Uses_Specified_DefaultFIlename_From_Arguments_When_Present()
+        [Theory, AutoMockData]
+        public void Uses_Specified_DefaultFIlename_From_Arguments_When_Present(
+            [Frozen] ICodeGenerationAssembly codeGenerationAssemblyMock, 
+            CodeGenerationAssemblyCommand sut)
         {
             // Act
-            _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}", "--default MyFile.txt");
+            _ = CommandLineCommandHelper.ExecuteCommand(sut, $"--name {GetType().Assembly.FullName}", "--default MyFile.txt");
 
             // Assert
-            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.DefaultFilename == "MyFile.txt"), Arg.Any<IGenerationEnvironment>());
+            codeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.DefaultFilename == "MyFile.txt"), Arg.Any<IGenerationEnvironment>());
         }
 
-        [Fact]
-        public void Uses_Empty_DefaultFilename_When_Not_Present_In_Arguments()
+        [Theory, AutoMockData]
+        public void Uses_Empty_DefaultFilename_When_Not_Present_In_Arguments(
+            [Frozen] ICodeGenerationAssembly codeGenerationAssemblyMock,
+            CodeGenerationAssemblyCommand sut)
         {
             // Act
-            _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}");
+            _ = CommandLineCommandHelper.ExecuteCommand(sut, $"--name {GetType().Assembly.FullName}");
 
             // Assert
-            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.DefaultFilename == string.Empty), Arg.Any<IGenerationEnvironment>());
+            codeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.DefaultFilename == string.Empty), Arg.Any<IGenerationEnvironment>());
         }
 
-        [Fact]
-        public void Uses_DryRun_When_DryRun_Option_Is_Present_In_Arguments()
+        [Theory, AutoMockData]
+        public void Uses_DryRun_When_DryRun_Option_Is_Present_In_Arguments(
+            [Frozen] ICodeGenerationAssembly codeGenerationAssemblyMock, 
+            CodeGenerationAssemblyCommand sut)
         {
             // Act
-            _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}", "--dryrun");
+            _ = CommandLineCommandHelper.ExecuteCommand(sut, $"--name {GetType().Assembly.FullName}", "--dryrun");
 
             // Assert
-            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.DryRun), Arg.Any<IGenerationEnvironment>());
+            codeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.DryRun), Arg.Any<IGenerationEnvironment>());
         }
 
-        [Fact]
-        public void Uses_DryRun_When_Cipboard_Option_Is_Present_In_Arguments()
+        [Theory, AutoMockData]
+        public void Uses_DryRun_When_Cipboard_Option_Is_Present_In_Arguments(
+            [Frozen] ICodeGenerationAssembly codeGenerationAssemblyMock, 
+            CodeGenerationAssemblyCommand sut)
         {
             // Act
-            _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}", "--clipboard");
+            _ = CommandLineCommandHelper.ExecuteCommand(sut, $"--name {GetType().Assembly.FullName}", "--clipboard");
 
             // Assert
-            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.DryRun), Arg.Any<IGenerationEnvironment>());
+            codeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.DryRun), Arg.Any<IGenerationEnvironment>());
         }
 
-        [Fact]
-        public void Uses_DryRun_When_Cipboard_And_DryRun_Options_Are_Present_In_Arguments()
+        [Theory, AutoMockData]
+        public void Uses_DryRun_When_Cipboard_And_DryRun_Options_Are_Present_In_Arguments(
+            [Frozen] ICodeGenerationAssembly codeGenerationAssemblyMock, 
+            CodeGenerationAssemblyCommand sut)
         {
             // Act
-            _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}", "--clipboard", "--dryrun");
+            _ = CommandLineCommandHelper.ExecuteCommand(sut, $"--name {GetType().Assembly.FullName}", "--clipboard", "--dryrun");
 
             // Assert
-            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.DryRun), Arg.Any<IGenerationEnvironment>());
+            codeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.DryRun), Arg.Any<IGenerationEnvironment>());
         }
 
-        [Fact]
-        public void Reports_Output_Directory_When_DryRun_Is_False_And_BasePath_Is_Specified()
+        [Theory, AutoMockData]
+        public void Reports_Output_Directory_When_DryRun_Is_False_And_BasePath_Is_Specified(CodeGenerationAssemblyCommand sut)
         {
             // Act
-            var output = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}", $"--path {TestData.BasePath}");
+            var output = CommandLineCommandHelper.ExecuteCommand(sut, $"--name {GetType().Assembly.FullName}", $"--path {TestData.BasePath}");
 
             // Assert
             output.Should().Be("Written code generation output to path: " + TestData.BasePath + Environment.NewLine);
         }
 
-        [Fact]
-        public void Reports_Output_Directory_When_DryRun_Is_Not_Specified_And_BasePath_Is_Not_Specified()
+        [Theory, AutoMockData]
+        public void Reports_Output_Directory_When_DryRun_Is_Not_Specified_And_BasePath_Is_Not_Specified(CodeGenerationAssemblyCommand sut)
         {
             // Act
-            var output = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}");
+            var output = CommandLineCommandHelper.ExecuteCommand(sut, $"--name {GetType().Assembly.FullName}");
 
             // Assert
             output.Should().Be("Written code generation output to path: " + Directory.GetCurrentDirectory() + Environment.NewLine);
         }
 
-        [Fact]
-        public void Does_Not_Report_Output_Directory_When_DryRun_Is_Not_Specified_And_BareOption_Is_Specified()
+        [Theory, AutoMockData]
+        public void Does_Not_Report_Output_Directory_When_DryRun_Is_Not_Specified_And_BareOption_Is_Specified(CodeGenerationAssemblyCommand sut)
         {
             // Act
-            var output = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}", "--bare");
+            var output = CommandLineCommandHelper.ExecuteCommand(sut, $"--name {GetType().Assembly.FullName}", "--bare");
 
             // Assert
             output.Should().BeEmpty();
         }
 
-        [Fact]
-        public void Copies_Output_To_Clipboard_When_ClipboardOption_Is_Specified()
+        [Theory, AutoMockData]
+        public void Copies_Output_To_Clipboard_When_ClipboardOption_Is_Specified(
+            [Frozen] ICodeGenerationAssembly codeGenerationAssemblyMock,
+            [Frozen] IClipboard clipboardMock,
+            CodeGenerationAssemblyCommand sut)
         {
             // Arrange
-            CodeGenerationAssemblyMock.When(x => x.Generate(Arg.Any<ICodeGenerationAssemblySettings>(), Arg.Any<IGenerationEnvironment>()))
+            codeGenerationAssemblyMock.When(x => x.Generate(Arg.Any<ICodeGenerationAssemblySettings>(), Arg.Any<IGenerationEnvironment>()))
                                       .Do(args =>
                                       {
                                           var x = args.ArgAt<MultipleContentBuilderEnvironment>(1);
                                           x.Builder.AddContent("MyFile.txt").Builder.Append("Hello!");
                                       });
             // Act
-            _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}", "--clipboard");
+            _ = CommandLineCommandHelper.ExecuteCommand(sut, $"--name {GetType().Assembly.FullName}", "--clipboard");
 
             // Assert
-            ClipboardMock.Received().SetText(@"MyFile.txt:
+            clipboardMock.Received().SetText(@"MyFile.txt:
 Hello!
 ");
         }
 
-        [Fact]
-        public void Reports_Output_Being_Copied_To_Clipboard_When_BareOption_Is_Not_Specified()
+        [Theory, AutoMockData]
+        public void Reports_Output_Being_Copied_To_Clipboard_When_BareOption_Is_Not_Specified(CodeGenerationAssemblyCommand sut)
         {
             // Act
-            var output = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}", "--clipboard");
+            var output = CommandLineCommandHelper.ExecuteCommand(sut, $"--name {GetType().Assembly.FullName}", "--clipboard");
 
             // Assert
             output.Should().Be("Copied code generation output to clipboard" + Environment.NewLine);
         }
 
-        [Fact]
-        public void Does_Not_Report_Output_Being_Copied_To_Clipboard_When_BareOption_Is_Specified()
+        [Theory, AutoMockData]
+        public void Does_Not_Report_Output_Being_Copied_To_Clipboard_When_BareOption_Is_Specified(CodeGenerationAssemblyCommand sut)
         {
             // Act
-            var output = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}", "--clipboard", "--bare");
+            var output = CommandLineCommandHelper.ExecuteCommand(sut, $"--name {GetType().Assembly.FullName}", "--clipboard", "--bare");
 
             // Assert
             output.Should().BeEmpty();
         }
 
-        [Fact]
-        public void Reports_Output_To_Host_When_DryRun_Option_Is_Present_In_Arguments_And_Clipboard_And_Bare_Options_Are_Not_Present_Without_BasePath()
+        [Theory, AutoMockData]
+        public void Reports_Output_To_Host_When_DryRun_Option_Is_Present_In_Arguments_And_Clipboard_And_Bare_Options_Are_Not_Present_Without_BasePath(
+            [Frozen] ICodeGenerationAssembly codeGenerationAssemblyMock,
+            CodeGenerationAssemblyCommand sut)
         {
             // Arrange
-            CodeGenerationAssemblyMock.When(x => x.Generate(Arg.Any<ICodeGenerationAssemblySettings>(), Arg.Any<IGenerationEnvironment>()))
+            codeGenerationAssemblyMock.When(x => x.Generate(Arg.Any<ICodeGenerationAssemblySettings>(), Arg.Any<IGenerationEnvironment>()))
                                       .Do(args =>
                                       {
                                           var x = args.ArgAt<MultipleContentBuilderEnvironment>(1);
@@ -239,7 +253,7 @@ Hello!
                                       });
 
             // Act
-            var output = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}", "--dryrun");
+            var output = CommandLineCommandHelper.ExecuteCommand(sut, $"--name {GetType().Assembly.FullName}", "--dryrun");
 
             // Assert
             output.Should().Be("Code generation output:" + Environment.NewLine + @"MyFile.txt:
@@ -247,11 +261,13 @@ Hello!
 " + Environment.NewLine);
         }
 
-        [Fact]
-        public void Reports_Output_To_Host_When_DryRun_Option_Is_Present_In_Arguments_And_Clipboard_And_Bare_Options_Are_Not_Present_With_BasePath()
+        [Theory, AutoMockData]
+        public void Reports_Output_To_Host_When_DryRun_Option_Is_Present_In_Arguments_And_Clipboard_And_Bare_Options_Are_Not_Present_With_BasePath(
+            [Frozen] ICodeGenerationAssembly codeGenerationAssemblyMock, 
+            CodeGenerationAssemblyCommand sut)
         {
             // Arrange
-            CodeGenerationAssemblyMock.When(x => x.Generate(Arg.Any<ICodeGenerationAssemblySettings>(), Arg.Any<IGenerationEnvironment>()))
+            codeGenerationAssemblyMock.When(x => x.Generate(Arg.Any<ICodeGenerationAssemblySettings>(), Arg.Any<IGenerationEnvironment>()))
                                       .Do(args =>
                                       {
                                           var x = args.ArgAt<MultipleContentBuilderEnvironment>(1);
@@ -259,7 +275,7 @@ Hello!
                                       });
 
             // Act
-            var output = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}", "--dryrun", $"--path {TestData.BasePath}");
+            var output = CommandLineCommandHelper.ExecuteCommand(sut, $"--name {GetType().Assembly.FullName}", "--dryrun", $"--path {TestData.BasePath}");
 
             // Assert
             output.Should().Be("Code generation output:" + Environment.NewLine + @$"{Path.Combine(TestData.BasePath, "MyFile.txt")}:

--- a/src/Console.Tests/Commands/CodeGenerationAssemblyCommandTests.cs
+++ b/src/Console.Tests/Commands/CodeGenerationAssemblyCommandTests.cs
@@ -14,7 +14,7 @@ public class CodeGenerationAssemblyCommandTests
         [Fact]
         public void Throws_On_Null_Argument()
         {
-            TestHelpers.ConstructorMustThrowArgumentNullException(typeof(CodeGenerationAssemblyCommand));
+            TestHelpers.ConstructorMustThrowArgumentNullException(typeof(CodeGenerationAssemblyCommand), t => ((Mock?)Activator.CreateInstance(typeof(Mock<>).MakeGenericType(t)))?.Object);
         }
     }
 

--- a/src/Console.Tests/Commands/CodeGenerationAssemblyCommandTests.cs
+++ b/src/Console.Tests/Commands/CodeGenerationAssemblyCommandTests.cs
@@ -2,19 +2,19 @@
 
 public class CodeGenerationAssemblyCommandTests
 {
-    protected Mock<ICodeGenerationAssembly> CodeGenerationAssemblyMock { get; } = new();
-    protected Mock<IClipboard> ClipboardMock { get; } = new();
-    protected Mock<IFileSystem> FileSystemMock { get; } = new();
-    protected Mock<IUserInput> UserInputMock { get; } = new();
+    protected ICodeGenerationAssembly CodeGenerationAssemblyMock { get; } = Substitute.For<ICodeGenerationAssembly>();
+    protected IClipboard ClipboardMock { get; } = Substitute.For<IClipboard>();
+    protected IFileSystem FileSystemMock { get; } = Substitute.For<IFileSystem>();
+    protected IUserInput UserInputMock { get; } = Substitute.For<IUserInput>();
 
-    private CodeGenerationAssemblyCommand CreateSut() => new(ClipboardMock.Object, FileSystemMock.Object, UserInputMock.Object, CodeGenerationAssemblyMock.Object);
+    private CodeGenerationAssemblyCommand CreateSut() => new(ClipboardMock, FileSystemMock, UserInputMock, CodeGenerationAssemblyMock);
 
     public class Constructor
     {
         [Fact]
         public void Throws_On_Null_Argument()
         {
-            TestHelpers.ConstructorMustThrowArgumentNullException(typeof(CodeGenerationAssemblyCommand), t => ((Mock?)Activator.CreateInstance(typeof(Mock<>).MakeGenericType(t)))?.Object);
+            TestHelpers.ConstructorMustThrowArgumentNullException(typeof(CodeGenerationAssemblyCommand), t => Substitute.For(new[] { t }, Array.Empty<object>()));
         }
     }
 
@@ -65,7 +65,7 @@ public class CodeGenerationAssemblyCommandTests
             _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}");
 
             // Assert
-            CodeGenerationAssemblyMock.Verify(x => x.Generate(It.Is<ICodeGenerationAssemblySettings>(x => x.CurrentDirectory == Directory.GetCurrentDirectory()), It.IsAny<IGenerationEnvironment>()), Times.Once);
+            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.CurrentDirectory == Directory.GetCurrentDirectory()), Arg.Any<IGenerationEnvironment>());
         }
 
         [Fact]
@@ -75,7 +75,7 @@ public class CodeGenerationAssemblyCommandTests
             _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {Path.Combine(TestData.BasePath, "myassembly.dll")}");
 
             // Assert
-            CodeGenerationAssemblyMock.Verify(x => x.Generate(It.Is<ICodeGenerationAssemblySettings>(x => x.CurrentDirectory == TestData.BasePath), It.IsAny<IGenerationEnvironment>()), Times.Once);
+            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.CurrentDirectory == TestData.BasePath), Arg.Any<IGenerationEnvironment>());
         }
 
         [Fact]
@@ -85,7 +85,7 @@ public class CodeGenerationAssemblyCommandTests
             _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {Path.Combine(TestData.BasePath, "myassembly.dll")}", "--directory something");
 
             // Assert
-            CodeGenerationAssemblyMock.Verify(x => x.Generate(It.Is<ICodeGenerationAssemblySettings>(x => x.CurrentDirectory == "something"), It.IsAny<IGenerationEnvironment>()), Times.Once);
+            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.CurrentDirectory == "something"), Arg.Any<IGenerationEnvironment>());
         }
 
         [Fact]
@@ -95,7 +95,7 @@ public class CodeGenerationAssemblyCommandTests
             _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}", $"--path {TestData.BasePath}");
 
             // Assert
-            CodeGenerationAssemblyMock.Verify(x => x.Generate(It.Is<ICodeGenerationAssemblySettings>(x => x.BasePath == TestData.BasePath), It.IsAny<IGenerationEnvironment>()), Times.Once);
+            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.BasePath == TestData.BasePath), Arg.Any<IGenerationEnvironment>());
         }
 
         [Fact]
@@ -105,7 +105,7 @@ public class CodeGenerationAssemblyCommandTests
             _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}");
 
             // Assert
-            CodeGenerationAssemblyMock.Verify(x => x.Generate(It.Is<ICodeGenerationAssemblySettings>(x => x.BasePath == string.Empty), It.IsAny<IGenerationEnvironment>()), Times.Once);
+            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.BasePath == string.Empty), Arg.Any<IGenerationEnvironment>());
         }
 
         [Fact]
@@ -115,7 +115,7 @@ public class CodeGenerationAssemblyCommandTests
             _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}", "--default MyFile.txt");
 
             // Assert
-            CodeGenerationAssemblyMock.Verify(x => x.Generate(It.Is<ICodeGenerationAssemblySettings>(x => x.DefaultFilename == "MyFile.txt"), It.IsAny<IGenerationEnvironment>()), Times.Once);
+            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.DefaultFilename == "MyFile.txt"), Arg.Any<IGenerationEnvironment>());
         }
 
         [Fact]
@@ -125,7 +125,7 @@ public class CodeGenerationAssemblyCommandTests
             _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}");
 
             // Assert
-            CodeGenerationAssemblyMock.Verify(x => x.Generate(It.Is<ICodeGenerationAssemblySettings>(x => x.DefaultFilename == string.Empty), It.IsAny<IGenerationEnvironment>()), Times.Once);
+            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.DefaultFilename == string.Empty), Arg.Any<IGenerationEnvironment>());
         }
 
         [Fact]
@@ -135,7 +135,7 @@ public class CodeGenerationAssemblyCommandTests
             _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}", "--dryrun");
 
             // Assert
-            CodeGenerationAssemblyMock.Verify(x => x.Generate(It.Is<ICodeGenerationAssemblySettings>(x => x.DryRun), It.IsAny<IGenerationEnvironment>()), Times.Once);
+            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.DryRun), Arg.Any<IGenerationEnvironment>());
         }
 
         [Fact]
@@ -145,7 +145,7 @@ public class CodeGenerationAssemblyCommandTests
             _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}", "--clipboard");
 
             // Assert
-            CodeGenerationAssemblyMock.Verify(x => x.Generate(It.Is<ICodeGenerationAssemblySettings>(x => x.DryRun), It.IsAny<IGenerationEnvironment>()), Times.Once);
+            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.DryRun), Arg.Any<IGenerationEnvironment>());
         }
 
         [Fact]
@@ -155,7 +155,7 @@ public class CodeGenerationAssemblyCommandTests
             _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}", "--clipboard", "--dryrun");
 
             // Assert
-            CodeGenerationAssemblyMock.Verify(x => x.Generate(It.Is<ICodeGenerationAssemblySettings>(x => x.DryRun), It.IsAny<IGenerationEnvironment>()), Times.Once);
+            CodeGenerationAssemblyMock.Received().Generate(Arg.Is<ICodeGenerationAssemblySettings>(x => x.DryRun), Arg.Any<IGenerationEnvironment>());
         }
 
         [Fact]
@@ -192,19 +192,19 @@ public class CodeGenerationAssemblyCommandTests
         public void Copies_Output_To_Clipboard_When_ClipboardOption_Is_Specified()
         {
             // Arrange
-            CodeGenerationAssemblyMock.Setup(x => x.Generate(It.IsAny<ICodeGenerationAssemblySettings>(), It.IsAny<IGenerationEnvironment>()))
-                                      .Callback<ICodeGenerationAssemblySettings, IGenerationEnvironment>((settings, env) =>
+            CodeGenerationAssemblyMock.When(x => x.Generate(Arg.Any<ICodeGenerationAssemblySettings>(), Arg.Any<IGenerationEnvironment>()))
+                                      .Do(args =>
                                       {
-                                          var x = (MultipleContentBuilderEnvironment)env;
+                                          var x = args.ArgAt<MultipleContentBuilderEnvironment>(1);
                                           x.Builder.AddContent("MyFile.txt").Builder.Append("Hello!");
                                       });
             // Act
             _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, $"--name {GetType().Assembly.FullName}", "--clipboard");
 
             // Assert
-            ClipboardMock.Verify(x => x.SetText(@"MyFile.txt:
+            ClipboardMock.Received().SetText(@"MyFile.txt:
 Hello!
-"), Times.Once);
+");
         }
 
         [Fact]
@@ -231,10 +231,10 @@ Hello!
         public void Reports_Output_To_Host_When_DryRun_Option_Is_Present_In_Arguments_And_Clipboard_And_Bare_Options_Are_Not_Present_Without_BasePath()
         {
             // Arrange
-            CodeGenerationAssemblyMock.Setup(x => x.Generate(It.IsAny<ICodeGenerationAssemblySettings>(), It.IsAny<IGenerationEnvironment>()))
-                                      .Callback<ICodeGenerationAssemblySettings, IGenerationEnvironment>((settings, env) =>
+            CodeGenerationAssemblyMock.When(x => x.Generate(Arg.Any<ICodeGenerationAssemblySettings>(), Arg.Any<IGenerationEnvironment>()))
+                                      .Do(args =>
                                       {
-                                          var x = (MultipleContentBuilderEnvironment)env;
+                                          var x = args.ArgAt<MultipleContentBuilderEnvironment>(1);
                                           x.Builder.AddContent("MyFile.txt").Builder.Append("Hello!");
                                       });
 
@@ -251,10 +251,10 @@ Hello!
         public void Reports_Output_To_Host_When_DryRun_Option_Is_Present_In_Arguments_And_Clipboard_And_Bare_Options_Are_Not_Present_With_BasePath()
         {
             // Arrange
-            CodeGenerationAssemblyMock.Setup(x => x.Generate(It.IsAny<ICodeGenerationAssemblySettings>(), It.IsAny<IGenerationEnvironment>()))
-                                      .Callback<ICodeGenerationAssemblySettings, IGenerationEnvironment>((settings, env) =>
+            CodeGenerationAssemblyMock.When(x => x.Generate(Arg.Any<ICodeGenerationAssemblySettings>(), Arg.Any<IGenerationEnvironment>()))
+                                      .Do(args =>
                                       {
-                                          var x = (MultipleContentBuilderEnvironment)env;
+                                          var x = args.ArgAt<MultipleContentBuilderEnvironment>(1);
                                           x.Builder.AddContent("MyFile.txt").Builder.Append("Hello!");
                                       });
 

--- a/src/Console.Tests/Commands/CommandBaseTests.cs
+++ b/src/Console.Tests/Commands/CommandBaseTests.cs
@@ -33,7 +33,7 @@ public class CommandBaseTests
         [Fact]
         public void Throws_On_Null_Argument()
         {
-            TestHelpers.ConstructorMustThrowArgumentNullException(typeof(CommandBaseTest));
+            TestHelpers.ConstructorMustThrowArgumentNullException(typeof(CommandBaseTest), t => ((Mock?)Activator.CreateInstance(typeof(Mock<>).MakeGenericType(t)))?.Object);
         }
     }
 

--- a/src/Console.Tests/Commands/CommandBaseTests.cs
+++ b/src/Console.Tests/Commands/CommandBaseTests.cs
@@ -26,7 +26,7 @@ public class CommandBaseTests
         [Fact]
         public void Throws_On_Null_Argument()
         {
-            TestHelpers.ConstructorMustThrowArgumentNullException(typeof(CommandBaseTest), t => Substitute.For(new[] { t }, Array.Empty<object>()));
+            typeof(CommandBaseTest).ShouldArgumentNullExceptionsInConstructorOnNullArguments();
         }
     }
 

--- a/src/Console.Tests/Commands/RunTemplateCommandTests.cs
+++ b/src/Console.Tests/Commands/RunTemplateCommandTests.cs
@@ -15,7 +15,7 @@ public class RunTemplateCommandTests
         [Fact]
         public void Throws_On_Null_Argument()
         {
-            TestHelpers.ConstructorMustThrowArgumentNullException(typeof(RunTemplateCommand));
+            TestHelpers.ConstructorMustThrowArgumentNullException(typeof(RunTemplateCommand), t => ((Mock?)Activator.CreateInstance(typeof(Mock<>).MakeGenericType(t)))?.Object);
         }
     }
 

--- a/src/Console.Tests/Commands/RunTemplateCommandTests.cs
+++ b/src/Console.Tests/Commands/RunTemplateCommandTests.cs
@@ -7,7 +7,7 @@ public class RunTemplateCommandTests
         [Fact]
         public void Throws_On_Null_Argument()
         {
-            TestHelpers.ConstructorMustThrowArgumentNullException(typeof(RunTemplateCommand), t => Substitute.For(new[] { t }, Array.Empty<object>()));
+            typeof(RunTemplateCommand).ShouldArgumentNullExceptionsInConstructorOnNullArguments();
         }
     }
 

--- a/src/Console.Tests/Commands/VersionCommandTests.cs
+++ b/src/Console.Tests/Commands/VersionCommandTests.cs
@@ -8,12 +8,11 @@ public class VersionCommandTests
         TestHelpers.ConstructorMustThrowArgumentNullException(typeof(VersionCommand), t => Substitute.For(new[] { t }, Array.Empty<object>()));
     }
 
-    [Fact]
-    public void Initialize_Adds_VersionCommand_To_Application()
+    [Theory, AutoMockData]
+    public void Initialize_Adds_VersionCommand_To_Application(VersionCommand sut)
     {
         // Arrange
         using var app = new CommandLineApplication();
-        var sut = new VersionCommand();
 
         // Act
         sut.Initialize(app);
@@ -22,12 +21,9 @@ public class VersionCommandTests
         app.Commands.Should().BeEmpty(); // aparently, this does not add a command that is publicly visible...
     }
 
-    [Fact]
-    public void Initialize_Throws_On_Null_Argument()
+    [Theory, AutoMockData]
+    public void Initialize_Throws_On_Null_Argument(VersionCommand sut)
     {
-        // Arrange
-        var sut = new VersionCommand();
-
         // Act & Assert
         sut.Invoking(x => x.Initialize(null!))
            .Should().Throw<ArgumentNullException>();

--- a/src/Console.Tests/Commands/VersionCommandTests.cs
+++ b/src/Console.Tests/Commands/VersionCommandTests.cs
@@ -5,7 +5,7 @@ public class VersionCommandTests
     [Fact]
     public void Ctor_Throws_On_Null_Argument()
     {
-        TestHelpers.ConstructorMustThrowArgumentNullException(typeof(VersionCommand), t => ((Mock?)Activator.CreateInstance(typeof(Mock<>).MakeGenericType(t)))?.Object);
+        TestHelpers.ConstructorMustThrowArgumentNullException(typeof(VersionCommand), t => Substitute.For(new[] { t }, Array.Empty<object>()));
     }
 
     [Fact]

--- a/src/Console.Tests/Commands/VersionCommandTests.cs
+++ b/src/Console.Tests/Commands/VersionCommandTests.cs
@@ -5,7 +5,7 @@ public class VersionCommandTests
     [Fact]
     public void Ctor_Throws_On_Null_Argument()
     {
-        TestHelpers.ConstructorMustThrowArgumentNullException(typeof(VersionCommand), t => Substitute.For(new[] { t }, Array.Empty<object>()));
+        typeof(VersionCommand).ShouldArgumentNullExceptionsInConstructorOnNullArguments();
     }
 
     [Theory, AutoMockData]

--- a/src/Console.Tests/Commands/VersionCommandTests.cs
+++ b/src/Console.Tests/Commands/VersionCommandTests.cs
@@ -5,7 +5,7 @@ public class VersionCommandTests
     [Fact]
     public void Ctor_Throws_On_Null_Argument()
     {
-        TestHelpers.ConstructorMustThrowArgumentNullException(typeof(VersionCommand));
+        TestHelpers.ConstructorMustThrowArgumentNullException(typeof(VersionCommand), t => ((Mock?)Activator.CreateInstance(typeof(Mock<>).MakeGenericType(t)))?.Object);
     }
 
     [Fact]

--- a/src/Console.Tests/ConsoleTestHelpers/CommandLineCommandHelper.cs
+++ b/src/Console.Tests/ConsoleTestHelpers/CommandLineCommandHelper.cs
@@ -2,6 +2,9 @@
 
 internal static class CommandLineCommandHelper
 {
+    internal static string ExecuteCommand<T>(T sut, params string[] arguments)
+        where T : ICommandLineCommand => ExecuteCommand(() => sut, arguments);
+
     internal static string ExecuteCommand<T>(Func<T> sutCreateDelegate, params string[] arguments)
         where T : ICommandLineCommand
     {

--- a/src/Console.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/Console.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Console.Tests.Extensions;
+namespace TemplateFramework.Console.Tests.Extensions;
 
 public class ServiceCollectionExtensionsTests
 {
@@ -13,9 +13,9 @@ public class ServiceCollectionExtensionsTests
             .AddTemplateFrameworkCodeGeneration()
             .AddTemplateFrameworkRuntime()
             .AddTemplateCommands()
-            .AddSingleton(new Mock<IAssemblyInfoContextService>().Object)
-            .AddSingleton(new Mock<ITemplateFactory>().Object)
-            .AddSingleton(new Mock<ITemplateComponentRegistryPluginFactory>().Object)
+            .AddSingleton(Substitute.For<IAssemblyInfoContextService>())
+            .AddSingleton(Substitute.For<ITemplateFactory>())
+            .AddSingleton(Substitute.For<ITemplateComponentRegistryPluginFactory>())
             .BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
 
         // Assert

--- a/src/Console.Tests/TemplateFramework.Console.Tests.csproj
+++ b/src/Console.Tests/TemplateFramework.Console.Tests.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -48,7 +48,7 @@
     <Using Include="CrossCutting.Common" />
     <Using Include="FluentAssertions" />
     <Using Include="McMaster.Extensions.CommandLineUtils" />
-    <Using Include="Moq;" />
+    <Using Include="NSubstitute" />
     <Using Include="Microsoft.Extensions.DependencyInjection" />
     <Using Include="System.Globalization" />
     <Using Include="System.Reflection" />

--- a/src/Console.Tests/TemplateFramework.Console.Tests.csproj
+++ b/src/Console.Tests/TemplateFramework.Console.Tests.csproj
@@ -29,7 +29,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="pauldeen79.CrossCutting.Common.Testing" Version="2.9.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -46,12 +45,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="CrossCutting.Common.Testing" />
+    <Using Include="CrossCutting.Common" />
     <Using Include="FluentAssertions" />
     <Using Include="McMaster.Extensions.CommandLineUtils" />
     <Using Include="Moq;" />
     <Using Include="Microsoft.Extensions.DependencyInjection" />
     <Using Include="System.Globalization" />
+    <Using Include="System.Reflection" />
     <Using Include="System.Text" />
     <Using Include="TemplateFramework.Abstractions" />
     <Using Include="TemplateFramework.Abstractions.CodeGeneration" />

--- a/src/Console.Tests/TemplateFramework.Console.Tests.csproj
+++ b/src/Console.Tests/TemplateFramework.Console.Tests.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="NSubstitute" Version="5.0.0" />
+    <PackageReference Include="Objectivity.AutoFixture.XUnit2.AutoNSubstitute" Version="3.5.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -45,10 +45,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Using Include="AutoFixture" />
+    <Using Include="AutoFixture.AutoNSubstitute" />
+    <Using Include="AutoFixture.Xunit2" />
     <Using Include="CrossCutting.Common" />
     <Using Include="FluentAssertions" />
     <Using Include="McMaster.Extensions.CommandLineUtils" />
     <Using Include="NSubstitute" />
+    <Using Include="Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Attributes" />
     <Using Include="Microsoft.Extensions.DependencyInjection" />
     <Using Include="System.Globalization" />
     <Using Include="System.Reflection" />

--- a/src/Console.Tests/TestHelpers.cs
+++ b/src/Console.Tests/TestHelpers.cs
@@ -1,0 +1,113 @@
+﻿namespace TemplateFramework.Console.Tests;
+
+public static class TestHelpers
+{
+    /// <summary>
+    /// Asserts that the specified type performs argument null checks on all arguments in all (public) constructors.
+    /// </summary>
+    /// <remarks>Note that this method throws an exeption when there is no public constructor.</remarks>
+    /// <param name="type">The type to assert null argument checks for.</param>
+    /// <param name="parameterPredicate">Optional predicate to apply to each parameter info. When the predicate returns false, then the parameter will be skipped.</param>
+    /// <param name="parameterReplaceDelegate">Optional function to apply to a parameter info. When the predicate is not defined, then we will create a mock or value type.</param>
+    public static void ConstructorMustThrowArgumentNullException(Type type,
+                                                                 Func<Type, object?> classFactory,
+                                                                 Func<ParameterInfo, bool>? parameterPredicate = null,
+                                                                 Func<ParameterInfo, object>? parameterReplaceDelegate = null)
+    {
+        type = ArgumentGuard.IsNotNull(type, nameof(type));
+        var ctors = ArgumentGuard.IsNotNull(type, nameof(type)).GetConstructors();
+        ctors.Should().Match<ConstructorInfo[]?>(x => x != null && x.Length > 0, $"Type {type.FullName} should have public constructors");
+
+        foreach (var constructor in ctors)
+        {
+            var parameters = constructor.GetParameters().ToArray();
+            var mocks = GetMocks(parameters, parameterReplaceDelegate, classFactory);
+
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                if (ShouldSkipParameter(parameterPredicate, parameters, i))
+                {
+                    continue;
+                }
+                var mocksCopy = mocks.ToArray();
+                mocksCopy[i] = FillParameter(parameters, i);
+
+                FixStringsAndArrays(parameters, i, mocksCopy);
+
+                try
+                {
+                    constructor.Invoke(mocksCopy);
+                    parameters[i].ParameterType.IsValueType.Should().BeFalse(string.Format(CultureInfo.InvariantCulture, "ArgumentNullException expected for parameter {0} of constructor, but no exception was thrown", parameters[i].Name));
+                }
+                catch (TargetInvocationException ex)
+                {
+                    ex.InnerException
+                        .Should().BeOfType<ArgumentNullException>()
+                        .And.Match<ArgumentNullException>(x => x.ParamName == parameters[i].Name);
+                }
+            }
+        }
+    }
+
+    private static object? FillParameter(ParameterInfo[] parameters, int i)
+        => parameters[i].ParameterType.IsValueType
+            ? Activator.CreateInstance(parameters[i].ParameterType)
+            : null;
+
+    private static bool ShouldSkipParameter(Func<ParameterInfo, bool>? parameterPredicate, ParameterInfo[] parameters, int i)
+        => parameterPredicate is not null
+            && !parameterPredicate.Invoke(parameters[i]);
+
+    private static object?[] GetMocks(ParameterInfo[] parameters, Func<ParameterInfo, object>? parameterReplaceDelegate, Func<Type, object?> classFactory)
+        => parameters.Select
+        (
+            p =>
+            {
+                if (parameterReplaceDelegate is not null)
+                {
+                    var returnValue = parameterReplaceDelegate.Invoke(p);
+                    if (returnValue is not null)
+                    {
+                        return returnValue;
+                    }
+                }
+
+                if (p.ParameterType == typeof(string))
+                {
+                    return string.Empty; // use string.Empty for string arguments, in case they require a null check
+                }
+                if (p.ParameterType.IsValueType || p.ParameterType.IsArray)
+                {
+                    return null; //skip value types and arrays
+                }
+                var mock = classFactory.Invoke(p.ParameterType);
+                mock = ArgumentGuard.IsNotNull(mock, nameof(mock));
+                return mock;
+            }
+        ).ToArray();
+
+    private static void FixStringsAndArrays(ParameterInfo[] parameters, int i, object?[] mocksCopy)
+    {
+        for (int j = 0; j < parameters.Length; j++)
+        {
+            if (j == i)
+            {
+                continue;
+            }
+            if (parameters[j].ParameterType.IsArray)
+            {
+                mocksCopy[j] = Activator.CreateInstance(parameters[j].ParameterType, 0);
+            }
+            else if (parameters[j].ParameterType.FullName?.StartsWith("System.Collections.Generic.IEnumerable", StringComparison.InvariantCulture) == true)
+            {
+                // note that for now, we only allow generic Enumerables to work.
+                // this needs to be extended to generic collections and lists of more types.
+                mocksCopy[j] = Activator.CreateInstance(typeof(List<>).MakeGenericType(parameters[j].ParameterType.GetGenericArguments()[0]));
+            }
+            else if (parameters[j].ParameterType == typeof(string))
+            {
+                mocksCopy[j] = string.Empty;
+            }
+        }
+    }
+}

--- a/src/Console/TemplateFramework.Console.csproj
+++ b/src/Console/TemplateFramework.Console.csproj
@@ -13,6 +13,9 @@
     <RepositoryUrl>https://github.com/pauldeen79/TemplateFramework</RepositoryUrl>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>tf</ToolCommandName>
+    <!-- Used by code coverage -->
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Core.CodeGeneration.Tests/CodeGenerationAssembly/CodeGenerationAssemblyTests.Constructor.cs
+++ b/src/Core.CodeGeneration.Tests/CodeGenerationAssembly/CodeGenerationAssemblyTests.Constructor.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.CodeGeneration.Tests;
+namespace TemplateFramework.Core.CodeGeneration.Tests;
 
 public partial class CodeGenerationAssemblyTests
 {
@@ -8,7 +8,7 @@ public partial class CodeGenerationAssemblyTests
         public void Throws_On_Null_CodeGenerationEngine()
         {
             // Act & Assert
-            this.Invoking(_ => new CodeGenerationAssembly(codeGenerationEngine: null!, assemblyService: AssemblyServiceMock.Object, creators: Enumerable.Empty<ICodeGenerationProviderCreator>()))
+            this.Invoking(_ => new CodeGenerationAssembly(codeGenerationEngine: null!, assemblyService: AssemblyServiceMock, creators: Enumerable.Empty<ICodeGenerationProviderCreator>()))
                 .Should().Throw<ArgumentNullException>().WithParameterName("codeGenerationEngine");
         }
 
@@ -16,7 +16,7 @@ public partial class CodeGenerationAssemblyTests
         public void Throws_On_Null_AssemblyService()
         {
             // Act & Assert
-            this.Invoking(_ => new CodeGenerationAssembly(codeGenerationEngine: CodeGenerationEngineMock.Object, assemblyService: null!, creators: Enumerable.Empty<ICodeGenerationProviderCreator>()))
+            this.Invoking(_ => new CodeGenerationAssembly(codeGenerationEngine: CodeGenerationEngineMock, assemblyService: null!, creators: Enumerable.Empty<ICodeGenerationProviderCreator>()))
                 .Should().Throw<ArgumentNullException>().WithParameterName("assemblyService");
         }
 
@@ -24,7 +24,7 @@ public partial class CodeGenerationAssemblyTests
         public void Throws_On_Null_Creators()
         {
             // Act & Assert
-            this.Invoking(_ => new CodeGenerationAssembly(codeGenerationEngine: CodeGenerationEngineMock.Object, assemblyService: AssemblyServiceMock.Object, creators: null!))
+            this.Invoking(_ => new CodeGenerationAssembly(codeGenerationEngine: CodeGenerationEngineMock, assemblyService: AssemblyServiceMock, creators: null!))
                 .Should().Throw<ArgumentNullException>().WithParameterName("creators");
         }
     }

--- a/src/Core.CodeGeneration.Tests/CodeGenerationAssembly/CodeGenerationAssemblyTests.Generate.cs
+++ b/src/Core.CodeGeneration.Tests/CodeGenerationAssembly/CodeGenerationAssemblyTests.Generate.cs
@@ -6,13 +6,11 @@ public partial class CodeGenerationAssemblyTests
     {
         public Generate()
         {
-            CodeGenerationProviderCreatorMock
-                .Setup(x => x.TryCreateInstance(It.IsAny<Type>()))
-                .Returns<Type>(t => t.FullName == typeof(MyGeneratorProvider).FullName
-                    ? Activator.CreateInstance(t) as ICodeGenerationProvider
+            CodeGenerationProviderCreatorMock.TryCreateInstance(Arg.Any<Type>())
+                .Returns(x => x.ArgAt<Type>(0).FullName == typeof(MyGeneratorProvider).FullName
+                    ? Activator.CreateInstance(x.ArgAt<Type>(0)) as ICodeGenerationProvider
                     : null);
-            AssemblyServiceMock
-                .Setup(x => x.GetAssembly(It.IsAny<string>(), It.IsAny<string>()))
+            AssemblyServiceMock.GetAssembly(Arg.Any<string>(), Arg.Any<string>())
                 .Returns(GetType().Assembly);
         }
 
@@ -23,7 +21,7 @@ public partial class CodeGenerationAssemblyTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.Generate(settings: null!, GenerationEnvironmentMock.Object))
+            sut.Invoking(x => x.Generate(settings: null!, GenerationEnvironmentMock))
                .Should().Throw<ArgumentNullException>().WithParameterName("settings");
         }
 
@@ -46,10 +44,10 @@ public partial class CodeGenerationAssemblyTests
             var sut = CreateSut();
 
             // Act
-            sut.Generate(new CodeGenerationAssemblySettings(TestData.BasePath, "DefaultFilename.txt", TestData.GetAssemblyName(), currentDirectory: TestData.BasePath), GenerationEnvironmentMock.Object);
+            sut.Generate(new CodeGenerationAssemblySettings(TestData.BasePath, "DefaultFilename.txt", TestData.GetAssemblyName(), currentDirectory: TestData.BasePath), GenerationEnvironmentMock);
 
             // Assert
-            CodeGenerationEngineMock.Verify(x => x.Generate(It.IsAny<ICodeGenerationProvider>(), It.IsAny<IGenerationEnvironment>(), It.IsAny<ICodeGenerationSettings>()), Times.Once);
+            CodeGenerationEngineMock.Received().Generate(Arg.Any<ICodeGenerationProvider>(), Arg.Any<IGenerationEnvironment>(), Arg.Any<ICodeGenerationSettings>());
         }
 
         [Fact]
@@ -59,10 +57,10 @@ public partial class CodeGenerationAssemblyTests
             var sut = CreateSut();
 
             // Act
-            sut.Generate(new CodeGenerationAssemblySettings(TestData.BasePath, "DefaultFilename.txt", TestData.GetAssemblyName(), currentDirectory: TestData.BasePath, classNameFilter: new[] { typeof(MyGeneratorProvider).FullName! }), GenerationEnvironmentMock.Object);
+            sut.Generate(new CodeGenerationAssemblySettings(TestData.BasePath, "DefaultFilename.txt", TestData.GetAssemblyName(), currentDirectory: TestData.BasePath, classNameFilter: new[] { typeof(MyGeneratorProvider).FullName! }), GenerationEnvironmentMock);
 
             // Assert
-            CodeGenerationEngineMock.Verify(x => x.Generate(It.IsAny<ICodeGenerationProvider>(), It.IsAny<IGenerationEnvironment>(), It.IsAny<ICodeGenerationSettings>()), Times.Once);
+            CodeGenerationEngineMock.Received().Generate(Arg.Any<ICodeGenerationProvider>(), Arg.Any<IGenerationEnvironment>(), Arg.Any<ICodeGenerationSettings>());
         }
 
         [Fact]
@@ -72,10 +70,10 @@ public partial class CodeGenerationAssemblyTests
             var sut = CreateSut();
 
             // Act
-            sut.Generate(new CodeGenerationAssemblySettings(TestData.BasePath, "DefaultFilename.txt", TestData.GetAssemblyName(), currentDirectory: TestData.BasePath, classNameFilter: new[] { "WrongName" }), GenerationEnvironmentMock.Object);
+            sut.Generate(new CodeGenerationAssemblySettings(TestData.BasePath, "DefaultFilename.txt", TestData.GetAssemblyName(), currentDirectory: TestData.BasePath, classNameFilter: new[] { "WrongName" }), GenerationEnvironmentMock);
 
             // Assert
-            CodeGenerationEngineMock.Verify(x => x.Generate(It.IsAny<ICodeGenerationProvider>(), It.IsAny<IGenerationEnvironment>(), It.IsAny<ICodeGenerationSettings>()), Times.Never);
+            CodeGenerationEngineMock.DidNotReceive().Generate(Arg.Any<ICodeGenerationProvider>(), Arg.Any<IGenerationEnvironment>(), Arg.Any<ICodeGenerationSettings>());
         }
     }
 }

--- a/src/Core.CodeGeneration.Tests/CodeGenerationAssembly/CodeGenerationAssemblyTests.cs
+++ b/src/Core.CodeGeneration.Tests/CodeGenerationAssembly/CodeGenerationAssemblyTests.cs
@@ -2,10 +2,10 @@
 
 public partial class CodeGenerationAssemblyTests
 {
-    protected Mock<ICodeGenerationEngine> CodeGenerationEngineMock { get; } = new();
-    protected Mock<IAssemblyService> AssemblyServiceMock { get; } = new();
-    protected Mock<IGenerationEnvironment> GenerationEnvironmentMock { get; } = new();
-    protected Mock<ICodeGenerationProviderCreator> CodeGenerationProviderCreatorMock { get; } = new();
+    protected ICodeGenerationEngine CodeGenerationEngineMock { get; } = Substitute.For<ICodeGenerationEngine>();
+    protected IAssemblyService AssemblyServiceMock { get; } = Substitute.For<IAssemblyService>();
+    protected IGenerationEnvironment GenerationEnvironmentMock { get; } = Substitute.For<IGenerationEnvironment>();
+    protected ICodeGenerationProviderCreator CodeGenerationProviderCreatorMock { get; } = Substitute.For<ICodeGenerationProviderCreator>();
 
-    protected CodeGenerationAssembly CreateSut() => new(CodeGenerationEngineMock.Object, AssemblyServiceMock.Object, new[] { CodeGenerationProviderCreatorMock.Object });
+    protected CodeGenerationAssembly CreateSut() => new(CodeGenerationEngineMock, AssemblyServiceMock, new[] { CodeGenerationProviderCreatorMock });
 }

--- a/src/Core.CodeGeneration.Tests/CodeGenerationEngine/CodeGenerationEngineTests.Constructor.cs
+++ b/src/Core.CodeGeneration.Tests/CodeGenerationEngine/CodeGenerationEngineTests.Constructor.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.CodeGeneration.Tests;
+namespace TemplateFramework.Core.CodeGeneration.Tests;
 
 public partial class CodeGenerationEngineTests
 {
@@ -7,21 +7,21 @@ public partial class CodeGenerationEngineTests
         [Fact]
         public void Throws_On_Null_TemplateEngine()
         {
-            this.Invoking(_ => new CodeGenerationEngine(templateEngine: null!, TemplateFactoryMock.Object, TemplateProviderMock.Object))
+            this.Invoking(_ => new CodeGenerationEngine(templateEngine: null!, TemplateFactoryMock, TemplateProviderMock))
                 .Should().Throw<ArgumentNullException>().WithParameterName("templateEngine");
         }
 
         [Fact]
         public void Throws_On_Null_TemplateFactory()
         {
-            this.Invoking(_ => new CodeGenerationEngine(TemplateEngineMock.Object, templateFactory: null!, TemplateProviderMock.Object))
+            this.Invoking(_ => new CodeGenerationEngine(TemplateEngineMock, templateFactory: null!, TemplateProviderMock))
                 .Should().Throw<ArgumentNullException>().WithParameterName("templateFactory");
         }
 
         [Fact]
         public void Throws_On_Null_TemplateProvider()
         {
-            this.Invoking(_ => new CodeGenerationEngine(TemplateEngineMock.Object, TemplateFactoryMock.Object, templateProvider: null!))
+            this.Invoking(_ => new CodeGenerationEngine(TemplateEngineMock, TemplateFactoryMock, templateProvider: null!))
                 .Should().Throw<ArgumentNullException>().WithParameterName("templateProvider");
         }
     }

--- a/src/Core.CodeGeneration.Tests/CodeGenerationEngine/CodeGenerationEngineTests.Generate.cs
+++ b/src/Core.CodeGeneration.Tests/CodeGenerationEngine/CodeGenerationEngineTests.Generate.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.CodeGeneration.Tests;
+namespace TemplateFramework.Core.CodeGeneration.Tests;
 
 public partial class CodeGenerationEngineTests
 {
@@ -11,7 +11,7 @@ public partial class CodeGenerationEngineTests
             var sut = CreateSut();
 
             // Act
-            sut.Invoking(x => x.Generate(codeGenerationProvider: null!, GenerationEnvironmentMock.Object, CodeGenerationSettingsMock.Object))
+            sut.Invoking(x => x.Generate(codeGenerationProvider: null!, GenerationEnvironmentMock, CodeGenerationSettingsMock))
                .Should().Throw<ArgumentNullException>().WithParameterName("codeGenerationProvider");
         }
 
@@ -22,7 +22,7 @@ public partial class CodeGenerationEngineTests
             var sut = CreateSut();
 
             // Act
-            sut.Invoking(x => x.Generate(CodeGenerationProviderMock.Object, generationEnvironment: null!, CodeGenerationSettingsMock.Object))
+            sut.Invoking(x => x.Generate(CodeGenerationProviderMock, generationEnvironment: null!, CodeGenerationSettingsMock))
                .Should().Throw<ArgumentNullException>().WithParameterName("generationEnvironment");
         }
 
@@ -33,7 +33,7 @@ public partial class CodeGenerationEngineTests
             var sut = CreateSut();
 
             // Act
-            sut.Invoking(x => x.Generate(CodeGenerationProviderMock.Object, GenerationEnvironmentMock.Object, settings: null!))
+            sut.Invoking(x => x.Generate(CodeGenerationProviderMock, GenerationEnvironmentMock, settings: null!))
                .Should().Throw<ArgumentNullException>().WithParameterName("settings");
         }
 
@@ -42,18 +42,18 @@ public partial class CodeGenerationEngineTests
         {
             // Arrange
             var sut = CreateSut();
-            CodeGenerationProviderMock.SetupGet(x => x.Encoding).Returns(Encoding.Latin1);
-            CodeGenerationProviderMock.SetupGet(x => x.Path).Returns(TestData.BasePath);
-            CodeGenerationProviderMock.Setup(x => x.GetGeneratorType()).Returns(GetType());
-            CodeGenerationSettingsMock.SetupGet(x => x.DryRun).Returns(false);
-            CodeGenerationSettingsMock.SetupGet(x => x.BasePath).Returns(TestData.BasePath);
-            CodeGenerationSettingsMock.SetupGet(x => x.DefaultFilename).Returns("Filename.txt");
+            CodeGenerationProviderMock.Encoding.Returns(Encoding.Latin1);
+            CodeGenerationProviderMock.Path.Returns(TestData.BasePath);
+            CodeGenerationProviderMock.GetGeneratorType().Returns(GetType());
+            CodeGenerationSettingsMock.DryRun.Returns(false);
+            CodeGenerationSettingsMock.BasePath.Returns(TestData.BasePath);
+            CodeGenerationSettingsMock.DefaultFilename.Returns("Filename.txt");
 
             // Act
-            sut.Generate(CodeGenerationProviderMock.Object, GenerationEnvironmentMock.Object, CodeGenerationSettingsMock.Object);
+            sut.Generate(CodeGenerationProviderMock, GenerationEnvironmentMock, CodeGenerationSettingsMock);
 
             // Assert
-            GenerationEnvironmentMock.Verify(x => x.SaveContents(CodeGenerationProviderMock.Object, TestData.BasePath, "Filename.txt"), Times.Once);
+            GenerationEnvironmentMock.Received().SaveContents(CodeGenerationProviderMock, TestData.BasePath, "Filename.txt");
         }
 
         [Fact]
@@ -61,17 +61,17 @@ public partial class CodeGenerationEngineTests
         {
             // Arrange
             var sut = CreateSut();
-            CodeGenerationProviderMock.SetupGet(x => x.Encoding).Returns(Encoding.Latin1);
-            CodeGenerationProviderMock.SetupGet(x => x.Path).Returns(TestData.BasePath);
-            CodeGenerationProviderMock.Setup(x => x.GetGeneratorType()).Returns(GetType());
-            CodeGenerationSettingsMock.SetupGet(x => x.DryRun).Returns(true);
-            CodeGenerationSettingsMock.SetupGet(x => x.DefaultFilename).Returns("Filename.txt");
+            CodeGenerationProviderMock.Encoding.Returns(Encoding.Latin1);
+            CodeGenerationProviderMock.Path.Returns(TestData.BasePath);
+            CodeGenerationProviderMock.GetGeneratorType().Returns(GetType());
+            CodeGenerationSettingsMock.DryRun.Returns(true);
+            CodeGenerationSettingsMock.DefaultFilename.Returns("Filename.txt");
 
             // Act
-            sut.Generate(CodeGenerationProviderMock.Object, GenerationEnvironmentMock.Object, CodeGenerationSettingsMock.Object);
+            sut.Generate(CodeGenerationProviderMock, GenerationEnvironmentMock, CodeGenerationSettingsMock);
 
             // Assert
-            GenerationEnvironmentMock.Verify(x => x.SaveContents(CodeGenerationProviderMock.Object, TestData.BasePath, "Filename.txt"), Times.Never);
+            GenerationEnvironmentMock.DidNotReceive().SaveContents(CodeGenerationProviderMock, TestData.BasePath, "Filename.txt");
         }
 
         [Fact]
@@ -81,12 +81,12 @@ public partial class CodeGenerationEngineTests
             var sut = CreateSut();
             var counter = 0;
             var provider = new MyPluginCodeGenerationProvider(_ => counter++);
-            CodeGenerationSettingsMock.SetupGet(x => x.DryRun).Returns(false);
-            CodeGenerationSettingsMock.SetupGet(x => x.BasePath).Returns(TestData.BasePath);
-            CodeGenerationSettingsMock.SetupGet(x => x.DefaultFilename).Returns("Filename.txt");
+            CodeGenerationSettingsMock.DryRun.Returns(false);
+            CodeGenerationSettingsMock.BasePath.Returns(TestData.BasePath);
+            CodeGenerationSettingsMock.DefaultFilename.Returns("Filename.txt");
 
             // Act
-            sut.Generate(provider, GenerationEnvironmentMock.Object, CodeGenerationSettingsMock.Object);
+            sut.Generate(provider, GenerationEnvironmentMock, CodeGenerationSettingsMock);
 
             // Assert
             counter.Should().Be(1);
@@ -97,17 +97,17 @@ public partial class CodeGenerationEngineTests
         {
             // Arrange
             var sut = CreateSut();
-            CodeGenerationProviderMock.SetupGet(x => x.Encoding).Returns(Encoding.Latin1);
-            CodeGenerationProviderMock.SetupGet(x => x.Path).Returns(TestData.BasePath);
-            CodeGenerationProviderMock.Setup(x => x.GetGeneratorType()).Returns(GetType());
-            CodeGenerationSettingsMock.SetupGet(x => x.DryRun).Returns(true);
-            CodeGenerationSettingsMock.SetupGet(x => x.DefaultFilename).Returns("Filename.txt");
+            CodeGenerationProviderMock.Encoding.Returns(Encoding.Latin1);
+            CodeGenerationProviderMock.Path.Returns(TestData.BasePath);
+            CodeGenerationProviderMock.GetGeneratorType().Returns(GetType());
+            CodeGenerationSettingsMock.DryRun.Returns(true);
+            CodeGenerationSettingsMock.DefaultFilename.Returns("Filename.txt");
 
             // Act
-            sut.Generate(CodeGenerationProviderMock.Object, GenerationEnvironmentMock.Object, CodeGenerationSettingsMock.Object);
+            sut.Generate(CodeGenerationProviderMock, GenerationEnvironmentMock, CodeGenerationSettingsMock);
 
             // Assert
-            TemplateProviderMock.Verify(x => x.StartSession(), Times.Once);
+            TemplateProviderMock.Received().StartSession();
         }
 
         private sealed class MyPluginCodeGenerationProvider : ICodeGenerationProvider, ITemplateComponentRegistryPlugin

--- a/src/Core.CodeGeneration.Tests/CodeGenerationEngine/CodeGenerationEngineTests.cs
+++ b/src/Core.CodeGeneration.Tests/CodeGenerationEngine/CodeGenerationEngineTests.cs
@@ -2,12 +2,12 @@
 
 public abstract partial class CodeGenerationEngineTests
 {
-    protected Mock<ITemplateEngine> TemplateEngineMock { get; } = new();
-    protected Mock<ITemplateFactory> TemplateFactoryMock { get; } = new();
-    protected Mock<ICodeGenerationProvider> CodeGenerationProviderMock { get; } = new();
-    protected Mock<ICodeGenerationSettings> CodeGenerationSettingsMock { get; } = new();
-    protected Mock<IGenerationEnvironment> GenerationEnvironmentMock { get; } = new();
-    protected Mock<ITemplateProvider> TemplateProviderMock { get; } = new();
+    protected ITemplateEngine TemplateEngineMock { get; } = Substitute.For<ITemplateEngine>();
+    protected ITemplateFactory TemplateFactoryMock { get; } = Substitute.For<ITemplateFactory>();
+    protected ICodeGenerationProvider CodeGenerationProviderMock { get; } = Substitute.For<ICodeGenerationProvider>();
+    protected ICodeGenerationSettings CodeGenerationSettingsMock { get; } = Substitute.For<ICodeGenerationSettings>();
+    protected IGenerationEnvironment GenerationEnvironmentMock { get; } = Substitute.For<IGenerationEnvironment>();
+    protected ITemplateProvider TemplateProviderMock { get; } = Substitute.For<ITemplateProvider>();
 
-    protected CodeGenerationEngine CreateSut() => new(TemplateEngineMock.Object, TemplateFactoryMock.Object, TemplateProviderMock.Object);
+    protected CodeGenerationEngine CreateSut() => new(TemplateEngineMock, TemplateFactoryMock, TemplateProviderMock);
 }

--- a/src/Core.CodeGeneration.Tests/Extensions/ServiceCollectionExtensions/ServiceCollectionExtensionsTests.AddTemplateFrameworkCodeGeneration.cs
+++ b/src/Core.CodeGeneration.Tests/Extensions/ServiceCollectionExtensions/ServiceCollectionExtensionsTests.AddTemplateFrameworkCodeGeneration.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.CodeGeneration.Tests.Extensions;
+namespace TemplateFramework.Core.CodeGeneration.Tests.Extensions;
 
 public class ServiceCollectionExtensionsTests
 {
@@ -12,9 +12,9 @@ public class ServiceCollectionExtensionsTests
                 .AddTemplateFramework()
                 .AddTemplateFrameworkCodeGeneration()
                 .AddTemplateFrameworkRuntime()
-                .AddSingleton(new Mock<IAssemblyInfoContextService>().Object)
-                .AddSingleton(new Mock<ITemplateFactory>().Object)
-                .AddSingleton(new Mock<ITemplateComponentRegistryPluginFactory>().Object)
+                .AddSingleton(Substitute.For<IAssemblyInfoContextService>())
+                .AddSingleton(Substitute.For<ITemplateFactory>())
+                .AddSingleton(Substitute.For<ITemplateComponentRegistryPluginFactory>())
                 .BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
 
             // Assert

--- a/src/Core.CodeGeneration.Tests/IntegrationTests.cs
+++ b/src/Core.CodeGeneration.Tests/IntegrationTests.cs
@@ -2,9 +2,9 @@
 
 public class IntegrationTests
 {
-    private readonly Mock<IFileSystem> _fileSystemMock = new();
-    private readonly Mock<ITemplateFactory> _templateFactoryMock = new();
-    private readonly Mock<ITemplateComponentRegistryPluginFactory> _templateProviderPluginFactoryMock = new();
+    private readonly IFileSystem _fileSystemMock = Substitute.For<IFileSystem>();
+    private readonly ITemplateFactory _templateFactoryMock = Substitute.For<ITemplateFactory>();
+    private readonly ITemplateComponentRegistryPluginFactory _templateProviderPluginFactoryMock = Substitute.For<ITemplateComponentRegistryPluginFactory>();
 
     [Fact]
     public void Can_Generate_Code_Using_CodeGenerationAssembly()
@@ -13,16 +13,16 @@ public class IntegrationTests
         using var serviceProvider = new ServiceCollection()
             .AddTemplateFramework()
             .AddTemplateFrameworkCodeGeneration()
-            .AddScoped(_ => _fileSystemMock.Object)
-            .AddScoped(_ => _templateFactoryMock.Object)
-            .AddScoped(_ => _templateProviderPluginFactoryMock.Object)
+            .AddScoped(_ => _fileSystemMock)
+            .AddScoped(_ => _templateFactoryMock)
+            .AddScoped(_ => _templateProviderPluginFactoryMock)
             .BuildServiceProvider(true);
         using var scope = serviceProvider.CreateScope();
         var sut = scope.ServiceProvider.GetRequiredService<ICodeGenerationEngine>();
         var codeGenerationProvider = new IntegrationProvider();
         var builder = new MultipleContentBuilder();
         var generationEnvironment = new MultipleContentBuilderEnvironment(scope.ServiceProvider.GetRequiredService<IFileSystem>(), scope.ServiceProvider.GetRequiredService<IRetryMechanism>(), builder);
-        _templateFactoryMock.Setup(x => x.Create(It.IsAny<Type>())).Returns<Type>(t => Activator.CreateInstance(t)!);
+        _templateFactoryMock.Create(Arg.Any<Type>()).Returns(x => Activator.CreateInstance(x.ArgAt<Type>(0))!);
 
         // Act
         sut.Generate(codeGenerationProvider, generationEnvironment, new CodeGenerationSettings(TestData.BasePath, "DefaultFilename.txt", false));

--- a/src/Core.CodeGeneration.Tests/TemplateFramework.Core.CodeGeneration.Tests.csproj
+++ b/src/Core.CodeGeneration.Tests/TemplateFramework.Core.CodeGeneration.Tests.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -45,28 +45,28 @@
   </ItemGroup>
 
   <ItemGroup>
-     <Using Include="System.Text" />
-     <Using Include="FluentAssertions" />
-     <Using Include="Microsoft.Extensions.DependencyInjection" />
-     <Using Include="Moq" />
-     <Using Include="System.Globalization" />
-     <Using Include="TemplateFramework.Abstractions" />
-     <Using Include="TemplateFramework.Abstractions.CodeGeneration" />
-     <Using Include="TemplateFramework.Abstractions.Domains" />
-     <Using Include="TemplateFramework.Abstractions.Extensions" />
-     <Using Include="TemplateFramework.Abstractions.Infrastructure" />
-     <Using Include="TemplateFramework.Abstractions.Requests" />
-     <Using Include="TemplateFramework.Abstractions.Templates" />
-     <Using Include="TemplateFramework.Core.Abstractions" />
-     <Using Include="TemplateFramework.Core.CodeGeneration.Abstractions" />
-     <Using Include="TemplateFramework.Core.CodeGeneration.CodeGeneratorProviderCreators" />
-     <Using Include="TemplateFramework.Core.CodeGeneration.Extensions" />
-     <Using Include="TemplateFramework.Core.Extensions" />
-     <Using Include="TemplateFramework.Core.GenerationEnvironments" />
-     <Using Include="TemplateFramework.Core.Requests" />
-     <Using Include="TemplateFramework.Runtime.Abstractions" />
-     <Using Include="TemplateFramework.Runtime.Extensions" />
-     <Using Include="Xunit" />
+    <Using Include="System.Text" />
+    <Using Include="FluentAssertions" />
+    <Using Include="Microsoft.Extensions.DependencyInjection" />
+    <Using Include="NSubstitute" />
+    <Using Include="System.Globalization" />
+    <Using Include="TemplateFramework.Abstractions" />
+    <Using Include="TemplateFramework.Abstractions.CodeGeneration" />
+    <Using Include="TemplateFramework.Abstractions.Domains" />
+    <Using Include="TemplateFramework.Abstractions.Extensions" />
+    <Using Include="TemplateFramework.Abstractions.Infrastructure" />
+    <Using Include="TemplateFramework.Abstractions.Requests" />
+    <Using Include="TemplateFramework.Abstractions.Templates" />
+    <Using Include="TemplateFramework.Core.Abstractions" />
+    <Using Include="TemplateFramework.Core.CodeGeneration.Abstractions" />
+    <Using Include="TemplateFramework.Core.CodeGeneration.CodeGeneratorProviderCreators" />
+    <Using Include="TemplateFramework.Core.CodeGeneration.Extensions" />
+    <Using Include="TemplateFramework.Core.Extensions" />
+    <Using Include="TemplateFramework.Core.GenerationEnvironments" />
+    <Using Include="TemplateFramework.Core.Requests" />
+    <Using Include="TemplateFramework.Runtime.Abstractions" />
+    <Using Include="TemplateFramework.Runtime.Extensions" />
+    <Using Include="Xunit" />
   </ItemGroup>
 
 </Project>

--- a/src/Core.CodeGeneration/TemplateFramework.Core.CodeGeneration.csproj
+++ b/src/Core.CodeGeneration/TemplateFramework.Core.CodeGeneration.csproj
@@ -10,6 +10,9 @@
     <PackageTags>templateengine;codegeneration</PackageTags>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/pauldeen79/TemplateFramework</RepositoryUrl>
+    <!-- Used by code coverage -->
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Core.Tests/ChildTemplateContextTests.cs
+++ b/src/Core.Tests/ChildTemplateContextTests.cs
@@ -1,10 +1,10 @@
-﻿namespace TemplateFramework.Core.Tests;
+namespace TemplateFramework.Core.Tests;
 
 public class ChildTemplateContextTests
 {
     protected const int IterationNumber = 13;
     protected const int IterationCount = 26;
-    protected ITemplateIdentifier Identifier { get; } = new Mock<ITemplateIdentifier>().Object;
+    protected ITemplateIdentifier Identifier { get; } = Substitute.For<ITemplateIdentifier>();
     protected object Model { get; } = new();
 
     public class Constructor : ChildTemplateContextTests

--- a/src/Core.Tests/Extensions/ServiceCollectionExtensions/ServiceCollectionExtensionsTests.AddTemplateFramework.cs
+++ b/src/Core.Tests/Extensions/ServiceCollectionExtensions/ServiceCollectionExtensionsTests.AddTemplateFramework.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests.Extensions;
+namespace TemplateFramework.Core.Tests.Extensions;
 
 public partial class ServiceCollectionExtensionsTests
 {
@@ -10,7 +10,7 @@ public partial class ServiceCollectionExtensionsTests
             // Act
             using var provider = new ServiceCollection()
                 .AddTemplateFramework()
-                .AddSingleton(new Mock<ITemplateComponentRegistryPluginFactory>().Object)
+                .AddSingleton(Substitute.For<ITemplateComponentRegistryPluginFactory>())
                 .BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
 
             // Assert

--- a/src/Core.Tests/Extensions/TemplateEngineExtensions/TemplateEngineExtensionsTests.RenderChildTemplate.cs
+++ b/src/Core.Tests/Extensions/TemplateEngineExtensions/TemplateEngineExtensionsTests.RenderChildTemplate.cs
@@ -8,284 +8,284 @@ public partial class TemplateEngineExtensionsTests
         public void RenderChildTemplate_Throws_On_Null_Context_1()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplate(Model, GenerationEnvironmentMock.Object, Identifier, context: null!))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("context");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplate(Model, GenerationEnvironmentMock, Identifier, context: null!))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("context");
         }
 
         [Fact]
         public void RenderChildTemplate_Renders_ChildTemplate_Correctly_1()
         {
             // Arrange
-            ContextMock.Setup(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>())).Returns(ContextMock.Object);
+            ContextMock.CreateChildContext(Arg.Any<IChildTemplateContext>()).Returns(ContextMock);
 
             // Act
-            TemplateEngineMock.Object.RenderChildTemplate(Model, GenerationEnvironmentMock.Object, Identifier, ContextMock.Object);
+            TemplateEngineMock.RenderChildTemplate(Model, GenerationEnvironmentMock, Identifier, ContextMock);
 
             // Assert
-            TemplateEngineMock.Verify(x => x.Render(It.Is<IRenderTemplateRequest>(request =>
+            TemplateEngineMock.Received().Render(Arg.Is<IRenderTemplateRequest>(request =>
                 request.AdditionalParameters == null
-                && request.Context == ContextMock.Object
+                && request.Context == ContextMock
                 && request.DefaultFilename == string.Empty
-                && request.GenerationEnvironment == GenerationEnvironmentMock.Object
+                && request.GenerationEnvironment == GenerationEnvironmentMock
                 && request.Model == Model
-                && request.Identifier == Identifier)), Times.Once());
-            ContextMock.Verify(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>()), Times.Once());
+                && request.Identifier == Identifier));
+            ContextMock.Received().CreateChildContext(Arg.Any<IChildTemplateContext>());
         }
 
         [Fact]
         public void RenderChildTemplate_Throws_On_Null_Context_2()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplate(Model, GenerationEnvironmentMock.Object, _ => Identifier, context: null!))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("context");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplate(Model, GenerationEnvironmentMock, _ => Identifier, context: null!))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("context");
         }
 
         [Fact]
         public void RenderChildTemplate_Throws_On_Null_IdentifierFactory_2()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplate(Model, GenerationEnvironmentMock.Object, identifierFactory: null!, ContextMock.Object))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("identifierFactory");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplate(Model, GenerationEnvironmentMock, identifierFactory: null!, ContextMock))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("identifierFactory");
         }
 
         [Fact]
         public void RenderChildTemplate_Renders_ChildTemplate_Correctly_2()
         {
             // Arrange
-            ContextMock.Setup(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>())).Returns(ContextMock.Object);
+            ContextMock.CreateChildContext(Arg.Any<IChildTemplateContext>()).Returns(ContextMock);
 
             // Act
-            TemplateEngineMock.Object.RenderChildTemplate(Model, GenerationEnvironmentMock.Object, _ => Identifier, ContextMock.Object);
+            TemplateEngineMock.RenderChildTemplate(Model, GenerationEnvironmentMock, _ => Identifier, ContextMock);
 
             // Assert
-            TemplateEngineMock.Verify(x => x.Render(It.Is<IRenderTemplateRequest>(request =>
+            TemplateEngineMock.Received().Render(Arg.Is<IRenderTemplateRequest>(request =>
                 request.AdditionalParameters == null
-                && request.Context == ContextMock.Object
+                && request.Context == ContextMock
                 && request.DefaultFilename == string.Empty
-                && request.GenerationEnvironment == GenerationEnvironmentMock.Object
+                && request.GenerationEnvironment == GenerationEnvironmentMock
                 && request.Model == Model
-                && request.Identifier == Identifier)), Times.Once());
-            ContextMock.Verify(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>()), Times.Once());
+                && request.Identifier == Identifier));
+            ContextMock.Received().CreateChildContext(Arg.Any<IChildTemplateContext>());
         }
         
         [Fact]
         public void RenderChildTemplate_Throws_On_Null_Context_3()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplate(GenerationEnvironmentMock.Object, Identifier, context: null!))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("context");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplate(GenerationEnvironmentMock, Identifier, context: null!))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("context");
         }
 
         [Fact]
         public void RenderChildTemplate_Renders_ChildTemplate_Correctly_3()
         {
             // Arrange
-            ContextMock.Setup(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>())).Returns(ContextMock.Object);
+            ContextMock.CreateChildContext(Arg.Any<IChildTemplateContext>()).Returns(ContextMock);
 
             // Act
-            TemplateEngineMock.Object.RenderChildTemplate(GenerationEnvironmentMock.Object, Identifier, ContextMock.Object);
+            TemplateEngineMock.RenderChildTemplate(GenerationEnvironmentMock, Identifier, ContextMock);
 
             // Assert
-            TemplateEngineMock.Verify(x => x.Render(It.Is<IRenderTemplateRequest>(request =>
+            TemplateEngineMock.Received().Render(Arg.Is<IRenderTemplateRequest>(request =>
                 request.AdditionalParameters == null
-                && request.Context == ContextMock.Object
+                && request.Context == ContextMock
                 && request.DefaultFilename == string.Empty
-                && request.GenerationEnvironment == GenerationEnvironmentMock.Object
+                && request.GenerationEnvironment == GenerationEnvironmentMock
                 && request.Model == null
-                && request.Identifier == Identifier)), Times.Once());
-            ContextMock.Verify(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>()), Times.Once());
+                && request.Identifier == Identifier));
+            ContextMock.Received().CreateChildContext(Arg.Any<IChildTemplateContext>());
         }
 
         [Fact]
         public void RenderChildTemplate_Throws_On_Null_Context_4()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplate(GenerationEnvironmentMock.Object, () => Identifier, context: null!))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("context");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplate(GenerationEnvironmentMock, () => Identifier, context: null!))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("context");
         }
 
         [Fact]
         public void RenderChildTemplate_Throws_On_Null_IdentifierFactory_4()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplate(GenerationEnvironmentMock.Object, identifierFactory: null!, ContextMock.Object))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("identifierFactory");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplate(GenerationEnvironmentMock, identifierFactory: null!, ContextMock))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("identifierFactory");
         }
 
         [Fact]
         public void RenderChildTemplate_Renders_ChildTemplate_Correctly_4()
         {
             // Arrange
-            ContextMock.Setup(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>())).Returns(ContextMock.Object);
+            ContextMock.CreateChildContext(Arg.Any<IChildTemplateContext>()).Returns(ContextMock);
 
             // Act
-            TemplateEngineMock.Object.RenderChildTemplate(GenerationEnvironmentMock.Object, () => Identifier, ContextMock.Object);
+            TemplateEngineMock.RenderChildTemplate(GenerationEnvironmentMock, () => Identifier, ContextMock);
 
             // Assert
-            TemplateEngineMock.Verify(x => x.Render(It.Is<IRenderTemplateRequest>(request =>
+            TemplateEngineMock.Received().Render(Arg.Is<IRenderTemplateRequest>(request =>
                 request.AdditionalParameters == null
-                && request.Context == ContextMock.Object
+                && request.Context == ContextMock
                 && request.DefaultFilename == string.Empty
-                && request.GenerationEnvironment == GenerationEnvironmentMock.Object
+                && request.GenerationEnvironment == GenerationEnvironmentMock
                 && request.Model == null
-                && request.Identifier == Identifier)), Times.Once());
-            ContextMock.Verify(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>()), Times.Once());
+                && request.Identifier == Identifier));
+            ContextMock.Received().CreateChildContext(Arg.Any<IChildTemplateContext>());
         }
 
         [Fact]
         public void RenderChildTemplate_Renders_ChildTemplate_Correctly_5()
         {
             // Act
-            TemplateEngineMock.Object.RenderChildTemplate(Model, GenerationEnvironmentMock.Object, Identifier);
+            TemplateEngineMock.RenderChildTemplate(Model, GenerationEnvironmentMock, Identifier);
 
             // Assert
-            TemplateEngineMock.Verify(x => x.Render(It.Is<IRenderTemplateRequest>(request =>
+            TemplateEngineMock.Received().Render(Arg.Is<IRenderTemplateRequest>(request =>
                 request.AdditionalParameters == null
                 && request.Context == null
                 && request.DefaultFilename == string.Empty
-                && request.GenerationEnvironment == GenerationEnvironmentMock.Object
+                && request.GenerationEnvironment == GenerationEnvironmentMock
                 && request.Model == Model
-                && request.Identifier == Identifier)), Times.Once());
+                && request.Identifier == Identifier));
         }
 
         [Fact]
         public void RenderChildTemplate_Throws_On_Null_IdentifierFactory_6()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplate(Model, GenerationEnvironmentMock.Object, identifierFactory: null!))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("identifierFactory");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplate(Model, GenerationEnvironmentMock, identifierFactory: null!))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("identifierFactory");
         }
 
         [Fact]
         public void RenderChildTemplate_Renders_ChildTemplate_Correctly_6()
         {
             // Act
-            TemplateEngineMock.Object.RenderChildTemplate(Model, GenerationEnvironmentMock.Object, _ => Identifier);
+            TemplateEngineMock.RenderChildTemplate(Model, GenerationEnvironmentMock, _ => Identifier);
 
             // Assert
-            TemplateEngineMock.Verify(x => x.Render(It.Is<IRenderTemplateRequest>(request =>
+            TemplateEngineMock.Received().Render(Arg.Is<IRenderTemplateRequest>(request =>
                 request.AdditionalParameters == null
                 && request.Context == null
                 && request.DefaultFilename == string.Empty
-                && request.GenerationEnvironment == GenerationEnvironmentMock.Object
+                && request.GenerationEnvironment == GenerationEnvironmentMock
                 && request.Model == Model
-                && request.Identifier == Identifier)), Times.Once());
+                && request.Identifier == Identifier));
         }
 
         [Fact]
         public void RenderChildTemplate_Renders_ChildTemplate_Correctly_7()
         {
             // Act
-            TemplateEngineMock.Object.RenderChildTemplate(GenerationEnvironmentMock.Object, Identifier);
+            TemplateEngineMock.RenderChildTemplate(GenerationEnvironmentMock, Identifier);
 
             // Assert
-            TemplateEngineMock.Verify(x => x.Render(It.Is<IRenderTemplateRequest>(request =>
+            TemplateEngineMock.Received().Render(Arg.Is<IRenderTemplateRequest>(request =>
                 request.AdditionalParameters == null
                 && request.Context == null
                 && request.DefaultFilename == string.Empty
-                && request.GenerationEnvironment == GenerationEnvironmentMock.Object
+                && request.GenerationEnvironment == GenerationEnvironmentMock
                 && request.Model == null
-                && request.Identifier == Identifier)), Times.Once());
+                && request.Identifier == Identifier));
         }
 
         [Fact]
         public void RenderChildTemplate_Throws_On_Null_IdentifierFactory_8()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplate(GenerationEnvironmentMock.Object, identifierFactory: null!))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("identifierFactory");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplate(GenerationEnvironmentMock, identifierFactory: null!))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("identifierFactory");
         }
 
         [Fact]
         public void RenderChildTemplate_Renders_ChildTemplate_Correctly_8()
         {
             // Act
-            TemplateEngineMock.Object.RenderChildTemplate(GenerationEnvironmentMock.Object, () => Identifier);
+            TemplateEngineMock.RenderChildTemplate(GenerationEnvironmentMock, () => Identifier);
 
             // Assert
-            TemplateEngineMock.Verify(x => x.Render(It.Is<IRenderTemplateRequest>(request =>
+            TemplateEngineMock.Received().Render(Arg.Is<IRenderTemplateRequest>(request =>
                 request.AdditionalParameters == null
                 && request.Context == null
                 && request.DefaultFilename == string.Empty
-                && request.GenerationEnvironment == GenerationEnvironmentMock.Object
+                && request.GenerationEnvironment == GenerationEnvironmentMock
                 && request.Model == null
-                && request.Identifier == Identifier)), Times.Once());
+                && request.Identifier == Identifier));
         }
 
         [Fact]
         public void RenderChildTemplate_Throws_On_Null_Context_9()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplate(Model, GenerationEnvironmentMock.Object, context: null!, TemplateIdentifierMock.Object))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("context");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplate(Model, GenerationEnvironmentMock, context: null!, TemplateIdentifierMock))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("context");
         }
 
         [Fact]
         public void RenderChildTemplate_Throws_On_Null_Identifier_9()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplate(Model, GenerationEnvironmentMock.Object, ContextMock.Object, identifier: null!))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("identifier");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplate(Model, GenerationEnvironmentMock, ContextMock, identifier: null!))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("identifier");
         }
 
         [Fact]
         public void RenderChildTemplate_Renders_ChildTemplate_Correctly_9()
         {
             // Arrange
-            ContextMock.SetupGet(x => x.DefaultFilename).Returns(DefaultFilename);
-            ContextMock.SetupGet(x => x.TemplateComponentRegistry).Returns(TemplateProviderMock.Object);
-            ContextMock.Setup(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>())).Returns(ContextMock.Object);
-            TemplateProviderMock.Setup(x => x.Create(It.IsAny<ITemplateIdentifier>())).Returns(Template);
+            ContextMock.DefaultFilename.Returns(DefaultFilename);
+            ContextMock.TemplateComponentRegistry.Returns(TemplateProviderMock);
+            ContextMock.CreateChildContext(Arg.Any<IChildTemplateContext>()).Returns(ContextMock);
+            TemplateProviderMock.Create(Arg.Any<ITemplateIdentifier>()).Returns(Template);
 
             // Act
-            TemplateEngineMock.Object.RenderChildTemplate(Model, GenerationEnvironmentMock.Object, ContextMock.Object, TemplateIdentifierMock.Object);
+            TemplateEngineMock.RenderChildTemplate(Model, GenerationEnvironmentMock, ContextMock, TemplateIdentifierMock);
 
             // Assert
-            TemplateEngineMock.Verify(x => x.Render(It.Is<IRenderTemplateRequest>(request =>
+            TemplateEngineMock.Received().Render(Arg.Is<IRenderTemplateRequest>(request =>
                 request.AdditionalParameters == null
-                && request.Context == ContextMock.Object
-                && request.DefaultFilename == ContextMock.Object.DefaultFilename
-                && request.GenerationEnvironment == GenerationEnvironmentMock.Object
+                && request.Context == ContextMock
+                && request.DefaultFilename == ContextMock.DefaultFilename
+                && request.GenerationEnvironment == GenerationEnvironmentMock
                 && request.Model == Model
-                && request.Identifier == Identifier)), Times.Once());
+                && request.Identifier == Identifier));
         }
 
         [Fact]
         public void RenderChildTemplate_Throws_On_Null_Context_10()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplate(GenerationEnvironmentMock.Object, context: null!, TemplateIdentifierMock.Object))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("context");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplate(GenerationEnvironmentMock, context: null!, TemplateIdentifierMock))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("context");
         }
 
         [Fact]
         public void RenderChildTemplate_Throws_On_Null_Identifier_10()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplate(GenerationEnvironmentMock.Object, ContextMock.Object, identifier: null!))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("identifier");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplate(GenerationEnvironmentMock, ContextMock, identifier: null!))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("identifier");
         }
 
         [Fact]
         public void RenderChildTemplate_Renders_ChildTemplate_Correctly_10()
         {
             // Arrange
-            ContextMock.SetupGet(x => x.DefaultFilename).Returns(DefaultFilename);
-            ContextMock.SetupGet(x => x.TemplateComponentRegistry).Returns(TemplateProviderMock.Object);
-            ContextMock.Setup(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>())).Returns(ContextMock.Object);
-            TemplateProviderMock.Setup(x => x.Create(It.IsAny<ITemplateIdentifier>())).Returns(Template);
+            ContextMock.DefaultFilename.Returns(DefaultFilename);
+            ContextMock.TemplateComponentRegistry.Returns(TemplateProviderMock);
+            ContextMock.CreateChildContext(Arg.Any<IChildTemplateContext>()).Returns(ContextMock);
+            TemplateProviderMock.Create(Arg.Any<ITemplateIdentifier>()).Returns(Template);
 
             // Act
-            TemplateEngineMock.Object.RenderChildTemplate(GenerationEnvironmentMock.Object, ContextMock.Object, TemplateIdentifierMock.Object);
+            TemplateEngineMock.RenderChildTemplate(GenerationEnvironmentMock, ContextMock, TemplateIdentifierMock);
 
             // Assert
-            TemplateEngineMock.Verify(x => x.Render(It.Is<IRenderTemplateRequest>(request =>
+            TemplateEngineMock.Received().Render(Arg.Is<IRenderTemplateRequest>(request =>
                 request.AdditionalParameters == null
-                && request.Context == ContextMock.Object
-                && request.DefaultFilename == ContextMock.Object.DefaultFilename
-                && request.GenerationEnvironment == GenerationEnvironmentMock.Object
+                && request.Context == ContextMock
+                && request.DefaultFilename == ContextMock.DefaultFilename
+                && request.GenerationEnvironment == GenerationEnvironmentMock
                 && request.Model == null
-                && request.Identifier == Identifier)), Times.Once());
+                && request.Identifier == Identifier));
         }
     }
 }

--- a/src/Core.Tests/Extensions/TemplateEngineExtensions/TemplateEngineExtensionsTests.RenderChildTemplates.cs
+++ b/src/Core.Tests/Extensions/TemplateEngineExtensions/TemplateEngineExtensionsTests.RenderChildTemplates.cs
@@ -8,254 +8,254 @@ public partial class TemplateEngineExtensionsTests
         public void Throws_On_Null_ChildModels_1()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplates(childModels: null!, GenerationEnvironmentMock.Object, Identifier, ContextMock.Object))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("childModels");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplates(childModels: null!, GenerationEnvironmentMock, Identifier, ContextMock))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("childModels");
         }
 
         [Fact]
         public void Throws_On_Null_Context_1()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplates(Models, GenerationEnvironmentMock.Object, Identifier, context: null!))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("context");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplates(Models, GenerationEnvironmentMock, Identifier, context: null!))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("context");
         }
 
         [Fact]
         public void Renders_All_Items_From_Model_1()
         {
             // Arrange
-            ContextMock.Setup(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>())).Returns(ContextMock.Object);
+            ContextMock.CreateChildContext(Arg.Any<IChildTemplateContext>()).Returns(ContextMock);
 
             // Act
-            TemplateEngineMock.Object.RenderChildTemplates(Models, GenerationEnvironmentMock.Object, Identifier, ContextMock.Object);
+            TemplateEngineMock.RenderChildTemplates(Models, GenerationEnvironmentMock, Identifier, ContextMock);
 
             // Assert
-            TemplateEngineMock.Verify(x => x.Render(It.Is<IRenderTemplateRequest>(request =>
+            TemplateEngineMock.Received(Models.Count()).Render(Arg.Is<IRenderTemplateRequest>(request =>
                 request.AdditionalParameters == null
-                && request.Context == ContextMock.Object
+                && request.Context == ContextMock
                 && request.DefaultFilename == string.Empty
-                && request.GenerationEnvironment == GenerationEnvironmentMock.Object
+                && request.GenerationEnvironment == GenerationEnvironmentMock
                 && request.Model != null
-                && request.Identifier == Identifier)), Times.Exactly(Models.Count()));
-            ContextMock.Verify(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>()), Times.Exactly(Models.Count()));
+                && request.Identifier == Identifier));
+            ContextMock.Received(Models.Count()).CreateChildContext(Arg.Any<IChildTemplateContext>());
         }
 
         [Fact]
         public void Throws_On_Null_ChildModels_2()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplates(childModels: null!, GenerationEnvironmentMock.Object, _ => Identifier, ContextMock.Object))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("childModels");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplates(childModels: null!, GenerationEnvironmentMock, _ => Identifier, ContextMock))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("childModels");
         }
 
         [Fact]
         public void Throws_On_Null_Context_2()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplates(Models, GenerationEnvironmentMock.Object, _ => Identifier, context: null!))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("context");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplates(Models, GenerationEnvironmentMock, _ => Identifier, context: null!))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("context");
         }
 
         [Fact]
         public void Renders_All_Items_From_Model_2()
         {
             // Arrange
-            ContextMock.Setup(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>())).Returns(ContextMock.Object);
+            ContextMock.CreateChildContext(Arg.Any<IChildTemplateContext>()).Returns(ContextMock);
 
             // Act
-            TemplateEngineMock.Object.RenderChildTemplates(Models, GenerationEnvironmentMock.Object, _ => Identifier, ContextMock.Object);
+            TemplateEngineMock.RenderChildTemplates(Models, GenerationEnvironmentMock, _ => Identifier, ContextMock);
 
             // Assert
-            TemplateEngineMock.Verify(x => x.Render(It.Is<IRenderTemplateRequest>(request =>
+            TemplateEngineMock.Received(Models.Count()).Render(Arg.Is<IRenderTemplateRequest>(request =>
                 request.AdditionalParameters == null
-                && request.Context == ContextMock.Object
+                && request.Context == ContextMock
                 && request.DefaultFilename == string.Empty
-                && request.GenerationEnvironment == GenerationEnvironmentMock.Object
+                && request.GenerationEnvironment == GenerationEnvironmentMock
                 && request.Model != null
-                && request.Identifier == Identifier)), Times.Exactly(Models.Count()));
-            ContextMock.Verify(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>()), Times.Exactly(Models.Count()));
+                && request.Identifier == Identifier));
+            ContextMock.Received(Models.Count()).CreateChildContext(Arg.Any<IChildTemplateContext>());
         }
 
         [Fact]
         public void Throws_On_Null_ChildModels_3()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplates(childModels: null!, GenerationEnvironmentMock.Object, Identifier))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("childModels");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplates(childModels: null!, GenerationEnvironmentMock, Identifier))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("childModels");
         }
 
         [Fact]
         public void Renders_All_Items_From_Model_3()
         {
             // Act
-            TemplateEngineMock.Object.RenderChildTemplates(Models, GenerationEnvironmentMock.Object, Identifier);
+            TemplateEngineMock.RenderChildTemplates(Models, GenerationEnvironmentMock, Identifier);
 
             // Assert
-            TemplateEngineMock.Verify(x => x.Render(It.Is<IRenderTemplateRequest>(request =>
+            TemplateEngineMock.Received(Models.Count()).Render(Arg.Is<IRenderTemplateRequest>(request =>
                 request.AdditionalParameters == null
                 && request.Context == null
                 && request.DefaultFilename == string.Empty
-                && request.GenerationEnvironment == GenerationEnvironmentMock.Object
+                && request.GenerationEnvironment == GenerationEnvironmentMock
                 && request.Model != null
-                && request.Identifier == Identifier)), Times.Exactly(Models.Count()));
+                && request.Identifier == Identifier));
         }
 
         [Fact]
         public void Throws_On_Null_ChildModels_4()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplates(childModels: null!, GenerationEnvironmentMock.Object, _ => Identifier))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("childModels");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplates(childModels: null!, GenerationEnvironmentMock, _ => Identifier))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("childModels");
         }
 
         [Fact]
         public void Renders_All_Items_From_Model_4()
         {
             // Act
-            TemplateEngineMock.Object.RenderChildTemplates(Models, GenerationEnvironmentMock.Object, _ => Identifier);
+            TemplateEngineMock.RenderChildTemplates(Models, GenerationEnvironmentMock, _ => Identifier);
 
             // Assert
-            TemplateEngineMock.Verify(x => x.Render(It.Is<IRenderTemplateRequest>(request =>
+            TemplateEngineMock.Received(Models.Count()).Render(Arg.Is<IRenderTemplateRequest>(request =>
                 request.AdditionalParameters == null
                 && request.Context == null
                 && request.DefaultFilename == string.Empty
-                && request.GenerationEnvironment == GenerationEnvironmentMock.Object
+                && request.GenerationEnvironment == GenerationEnvironmentMock
                 && request.Model != null
-                && request.Identifier == Identifier)), Times.Exactly(Models.Count()));
+                && request.Identifier == Identifier));
         }
 
         [Fact]
         public void Throws_On_Null_ChildModels_5()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplates(childModels: null!, GenerationEnvironmentMock.Object, ContextMock.Object, _ => TemplateIdentifierMock.Object))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("childModels");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplates(childModels: null!, GenerationEnvironmentMock, ContextMock, _ => TemplateIdentifierMock))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("childModels");
         }
 
         [Fact]
         public void Throws_On_Null_Context_5()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplates(Models, GenerationEnvironmentMock.Object, context: null!, _ => TemplateIdentifierMock.Object))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("context");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplates(Models, GenerationEnvironmentMock, context: null!, _ => TemplateIdentifierMock))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("context");
         }
 
         [Fact]
         public void Throws_On_Null_TemplateIdentifierFactory_5()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplates(Models, GenerationEnvironmentMock.Object, ContextMock.Object, templateIdentifierFactory: null!))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("templateIdentifierFactory");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplates(Models, GenerationEnvironmentMock, ContextMock, templateIdentifierFactory: null!))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("templateIdentifierFactory");
         }
 
         [Fact]
         public void Renders_All_Items_From_Model_5()
         {
             // Arrange
-            ContextMock.Setup(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>())).Returns(ContextMock.Object);
-            ContextMock.SetupGet(x => x.DefaultFilename).Returns(DefaultFilename);
-            ContextMock.SetupGet(x => x.TemplateComponentRegistry).Returns(TemplateProviderMock.Object);
-            TemplateProviderMock.Setup(x => x.Create(It.IsAny<ITemplateIdentifier>())).Returns(Template);
+            ContextMock.CreateChildContext(Arg.Any<IChildTemplateContext>()).Returns(ContextMock);
+            ContextMock.DefaultFilename.Returns(DefaultFilename);
+            ContextMock.TemplateComponentRegistry.Returns(TemplateProviderMock);
+            TemplateProviderMock.Create(Arg.Any<ITemplateIdentifier>()).Returns(Template);
 
             // Act
-            TemplateEngineMock.Object.RenderChildTemplates(Models, GenerationEnvironmentMock.Object, ContextMock.Object, _ => TemplateIdentifierMock.Object);
+            TemplateEngineMock.RenderChildTemplates(Models, GenerationEnvironmentMock, ContextMock, _ => TemplateIdentifierMock);
 
             // Assert
-            TemplateEngineMock.Verify(x => x.Render(It.Is<IRenderTemplateRequest>(request =>
+            TemplateEngineMock.Received(Models.Count()).Render(Arg.Is<IRenderTemplateRequest>(request =>
                 request.AdditionalParameters == null
-                && request.Context == ContextMock.Object
-                && request.DefaultFilename == ContextMock.Object.DefaultFilename
-                && request.GenerationEnvironment == GenerationEnvironmentMock.Object
+                && request.Context == ContextMock
+                && request.DefaultFilename == ContextMock.DefaultFilename
+                && request.GenerationEnvironment == GenerationEnvironmentMock
                 && request.Model != null
-                && request.Identifier == Identifier)), Times.Exactly(Models.Count()));
+                && request.Identifier == Identifier));
         }
 
         [Fact]
         public void Throws_On_Null_ChildModels_6()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplates(childModels: null!, GenerationEnvironmentMock.Object, ContextMock.Object, _ => Template))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("childModels");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplates(childModels: null!, GenerationEnvironmentMock, ContextMock, _ => Template))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("childModels");
         }
 
         [Fact]
         public void Throws_On_Null_Context_6()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplates(Models, GenerationEnvironmentMock.Object, context: null!, _ => Template))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("context");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplates(Models, GenerationEnvironmentMock, context: null!, _ => Template))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("context");
         }
 
         [Fact]
         public void Throws_On_Null_TemplateIdentifierFactory_6()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplates(Models, GenerationEnvironmentMock.Object, ContextMock.Object, templateIdentifierFactory: null!))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("templateIdentifierFactory");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplates(Models, GenerationEnvironmentMock, ContextMock, templateIdentifierFactory: null!))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("templateIdentifierFactory");
         }
 
         [Fact]
         public void Renders_All_Items_From_Model_6()
         {
             // Arrange
-            ContextMock.Setup(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>())).Returns(ContextMock.Object);
-            ContextMock.SetupGet(x => x.DefaultFilename).Returns(DefaultFilename);
+            ContextMock.CreateChildContext(Arg.Any<IChildTemplateContext>()).Returns(ContextMock);
+            ContextMock.DefaultFilename.Returns(DefaultFilename);
 
             // Act
-            TemplateEngineMock.Object.RenderChildTemplates(Models, GenerationEnvironmentMock.Object, ContextMock.Object, _ => Template);
+            TemplateEngineMock.RenderChildTemplates(Models, GenerationEnvironmentMock, ContextMock, _ => Template);
 
             // Assert
-            TemplateEngineMock.Verify(x => x.Render(It.Is<IRenderTemplateRequest>(request =>
+            TemplateEngineMock.Received(Models.Count()).Render(Arg.Is<IRenderTemplateRequest>(request =>
                 request.AdditionalParameters == null
-                && request.Context == ContextMock.Object
-                && request.DefaultFilename == ContextMock.Object.DefaultFilename
-                && request.GenerationEnvironment == GenerationEnvironmentMock.Object
+                && request.Context == ContextMock
+                && request.DefaultFilename == ContextMock.DefaultFilename
+                && request.GenerationEnvironment == GenerationEnvironmentMock
                 && request.Model != null
-                && request.Identifier != null)), Times.Exactly(Models.Count()));
+                && request.Identifier != null));
         }
 
         [Fact]
         public void Throws_On_Null_ChildModels_7()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplates(childModels: null!, GenerationEnvironmentMock.Object, ContextMock.Object, Identifier))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("childModels");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplates(childModels: null!, GenerationEnvironmentMock, ContextMock, Identifier))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("childModels");
         }
 
         [Fact]
         public void Throws_On_Null_Context_7()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplates(Models, GenerationEnvironmentMock.Object, context: null!, Identifier))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("context");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplates(Models, GenerationEnvironmentMock, context: null!, Identifier))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("context");
         }
 
         [Fact]
         public void Throws_On_Null_Identifier_7()
         {
             // Act & Assert
-            TemplateEngineMock.Object.Invoking(x => x.RenderChildTemplates(Models, GenerationEnvironmentMock.Object, ContextMock.Object, identifier: null!))
-                                     .Should().Throw<ArgumentNullException>().WithParameterName("identifier");
+            TemplateEngineMock.Invoking(x => x.RenderChildTemplates(Models, GenerationEnvironmentMock, ContextMock, identifier: null!))
+                              .Should().Throw<ArgumentNullException>().WithParameterName("identifier");
         }
 
         [Fact]
         public void Renders_All_Items_From_Model_7()
         {
             // Arrange
-            ContextMock.Setup(x => x.CreateChildContext(It.IsAny<IChildTemplateContext>())).Returns(ContextMock.Object);
-            ContextMock.SetupGet(x => x.DefaultFilename).Returns(DefaultFilename);
+            ContextMock.CreateChildContext(Arg.Any<IChildTemplateContext>()).Returns(ContextMock);
+            ContextMock.DefaultFilename.Returns(DefaultFilename);
 
             // Act
-            TemplateEngineMock.Object.RenderChildTemplates(Models, GenerationEnvironmentMock.Object, ContextMock.Object, Identifier);
+            TemplateEngineMock.RenderChildTemplates(Models, GenerationEnvironmentMock, ContextMock, Identifier);
 
             // Assert
-            TemplateEngineMock.Verify(x => x.Render(It.Is<IRenderTemplateRequest>(request =>
+            TemplateEngineMock.Received(Models.Count()).Render(Arg.Is<IRenderTemplateRequest>(request =>
                 request.AdditionalParameters == null
-                && request.Context == ContextMock.Object
-                && request.DefaultFilename == ContextMock.Object.DefaultFilename
-                && request.GenerationEnvironment == GenerationEnvironmentMock.Object
+                && request.Context == ContextMock
+                && request.DefaultFilename == ContextMock.DefaultFilename
+                && request.GenerationEnvironment == GenerationEnvironmentMock
                 && request.Model != null
-                && request.Identifier == Identifier)), Times.Exactly(Models.Count()));
+                && request.Identifier == Identifier));
         }
     }
 }

--- a/src/Core.Tests/Extensions/TemplateEngineExtensions/TemplateEngineExtensionsTests.cs
+++ b/src/Core.Tests/Extensions/TemplateEngineExtensions/TemplateEngineExtensionsTests.cs
@@ -2,14 +2,14 @@
 
 public partial class TemplateEngineExtensionsTests
 {
-    protected Mock<ITemplateEngine> TemplateEngineMock { get; } = new();
-    protected Mock<ITemplateProvider> TemplateProviderMock { get; } = new();
-    protected Mock<IGenerationEnvironment> GenerationEnvironmentMock { get; } = new();
-    protected Mock<ITemplateContext> ContextMock { get; } = new();
-    protected Mock<ITemplateIdentifier> TemplateIdentifierMock { get; } = new();
+    protected ITemplateEngine TemplateEngineMock { get; } = Substitute.For<ITemplateEngine>();
+    protected ITemplateProvider TemplateProviderMock { get; } = Substitute.For<ITemplateProvider>();
+    protected IGenerationEnvironment GenerationEnvironmentMock { get; } = Substitute.For<IGenerationEnvironment>();
+    protected ITemplateContext ContextMock { get; } = Substitute.For<ITemplateContext>();
+    protected ITemplateIdentifier TemplateIdentifierMock { get; } = Substitute.For<ITemplateIdentifier>();
 
     protected object Template { get; } = new object();
-    protected ITemplateIdentifier Identifier => TemplateIdentifierMock.Object;
+    protected ITemplateIdentifier Identifier => TemplateIdentifierMock;
     protected IEnumerable<object?> Models { get; } = new[] { new object(), new object(), new object() };
     protected object Model { get; } = new object();
 

--- a/src/Core.Tests/GenerationEnvironments/MultipleContentBuilderEnvironment/MultipleContentBuilderEnvironmentTests.Constructor.cs
+++ b/src/Core.Tests/GenerationEnvironments/MultipleContentBuilderEnvironment/MultipleContentBuilderEnvironmentTests.Constructor.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests.GenerationEnvironments;
+namespace TemplateFramework.Core.Tests.GenerationEnvironments;
 
 public partial class MultipleContentBuilderEnvironmentTests
 {
@@ -8,7 +8,7 @@ public partial class MultipleContentBuilderEnvironmentTests
         public void Throws_On_Null_Builder()
         {
             // Act & Assert
-            this.Invoking(_ => new MultipleContentBuilderEnvironment(FileSystemMock.Object, RetryMechanism, builder: null!))
+            this.Invoking(_ => new MultipleContentBuilderEnvironment(FileSystemMock, RetryMechanism, builder: null!))
                 .Should().Throw<ArgumentNullException>().WithParameterName("builder");
         }
 
@@ -19,7 +19,7 @@ public partial class MultipleContentBuilderEnvironmentTests
             var instance = CreateSut();
 
             // Assert
-            instance.Builder.Should().BeSameAs(MultipleContentBuilderMock.Object);
+            instance.Builder.Should().BeSameAs(MultipleContentBuilderMock);
         }
 
         [Fact]

--- a/src/Core.Tests/GenerationEnvironments/MultipleContentBuilderEnvironment/MultipleContentBuilderEnvironmentTests.DeleteLastGeneratedFiles.cs
+++ b/src/Core.Tests/GenerationEnvironments/MultipleContentBuilderEnvironment/MultipleContentBuilderEnvironmentTests.DeleteLastGeneratedFiles.cs
@@ -11,7 +11,7 @@ public partial class MultipleContentBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.DeleteLastGeneratedFiles(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, lastGeneratedFilesPath: null!, false))
+            sut.Invoking(x => x.DeleteLastGeneratedFiles(FileSystemMock, TestData.BasePath, Encoding.Latin1, lastGeneratedFilesPath: null!, false))
                .Should().Throw<ArgumentNullException>().WithParameterName("lastGeneratedFilesPath");
         }
 
@@ -22,7 +22,7 @@ public partial class MultipleContentBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.DeleteLastGeneratedFiles(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, lastGeneratedFilesPath: string.Empty, false))
+            sut.Invoking(x => x.DeleteLastGeneratedFiles(FileSystemMock, TestData.BasePath, Encoding.Latin1, lastGeneratedFilesPath: string.Empty, false))
                .Should().Throw<ArgumentException>().WithParameterName("lastGeneratedFilesPath");
         }
 
@@ -33,7 +33,7 @@ public partial class MultipleContentBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.DeleteLastGeneratedFiles(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, lastGeneratedFilesPath: " ", false))
+            sut.Invoking(x => x.DeleteLastGeneratedFiles(FileSystemMock, TestData.BasePath, Encoding.Latin1, lastGeneratedFilesPath: " ", false))
                .Should().Throw<ArgumentException>().WithParameterName("lastGeneratedFilesPath");
         }
 
@@ -44,7 +44,7 @@ public partial class MultipleContentBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.DeleteLastGeneratedFiles(FileSystemMock.Object, TestData.BasePath, encoding: null!, "LastGeneratedFiles.txt", true))
+            sut.Invoking(x => x.DeleteLastGeneratedFiles(FileSystemMock, TestData.BasePath, encoding: null!, "LastGeneratedFiles.txt", true))
                .Should().Throw<ArgumentNullException>().WithParameterName("encoding");
         }
 
@@ -55,10 +55,10 @@ public partial class MultipleContentBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act
-            sut.DeleteLastGeneratedFiles(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, Path.Combine("MyDirectory", "LastGeneratedFiles.txt"), false);
+            sut.DeleteLastGeneratedFiles(FileSystemMock, TestData.BasePath, Encoding.Latin1, Path.Combine("MyDirectory", "LastGeneratedFiles.txt"), false);
 
             // Assert
-            FileSystemMock.Verify(x => x.FileExists(Path.Combine(TestData.BasePath, "MyDirectory", "LastGeneratedFiles.txt")), Times.Once);
+            FileSystemMock.Received().FileExists(Path.Combine(TestData.BasePath, "MyDirectory", "LastGeneratedFiles.txt"));
         }
 
         [Fact]
@@ -68,10 +68,10 @@ public partial class MultipleContentBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act
-            sut.DeleteLastGeneratedFiles(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, "LastGeneratedFiles.txt", false);
+            sut.DeleteLastGeneratedFiles(FileSystemMock, TestData.BasePath, Encoding.Latin1, "LastGeneratedFiles.txt", false);
 
             // Assert
-            FileSystemMock.Verify(x => x.FileExists(Path.Combine(TestData.BasePath, "LastGeneratedFiles.txt")), Times.Once);
+            FileSystemMock.Received().FileExists(Path.Combine(TestData.BasePath, "LastGeneratedFiles.txt"));
         }
 
         [Fact]
@@ -81,10 +81,10 @@ public partial class MultipleContentBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act
-            sut.DeleteLastGeneratedFiles(FileSystemMock.Object, string.Empty, Encoding.Latin1, "LastGeneratedFiles.txt", false);
+            sut.DeleteLastGeneratedFiles(FileSystemMock, string.Empty, Encoding.Latin1, "LastGeneratedFiles.txt", false);
 
             // Assert
-            FileSystemMock.Verify(x => x.FileExists("LastGeneratedFiles.txt"), Times.Once);
+            FileSystemMock.Received().FileExists("LastGeneratedFiles.txt");
         }
 
         [Fact]
@@ -92,14 +92,14 @@ public partial class MultipleContentBuilderEnvironmentTests
         {
             // Arrange
             var sut = CreateSut();
-            FileSystemMock.Setup(x => x.DirectoryExists(TestData.BasePath)).Returns(false);
+            FileSystemMock.DirectoryExists(TestData.BasePath).Returns(false);
 
             // Act
-            sut.DeleteLastGeneratedFiles(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, "*.generated.cs", false);
+            sut.DeleteLastGeneratedFiles(FileSystemMock, TestData.BasePath, Encoding.Latin1, "*.generated.cs", false);
 
             // Assert
-            FileSystemMock.Verify(x => x.FileExists(It.IsAny<string>()), Times.Never);
-            FileSystemMock.Verify(x => x.FileDelete(It.IsAny<string>()), Times.Never);
+            FileSystemMock.DidNotReceive().FileExists(Arg.Any<string>());
+            FileSystemMock.DidNotReceive().FileDelete(Arg.Any<string>());
         }
 
         [Fact]
@@ -107,14 +107,14 @@ public partial class MultipleContentBuilderEnvironmentTests
         {
             // Arrange
             var sut = CreateSut();
-            FileSystemMock.Setup(x => x.DirectoryExists(TestData.BasePath)).Returns(true);
+            FileSystemMock.DirectoryExists(TestData.BasePath).Returns(true);
 
             // Act
-            sut.DeleteLastGeneratedFiles(FileSystemMock.Object, string.Empty, Encoding.Latin1, "*.generated.cs", false);
+            sut.DeleteLastGeneratedFiles(FileSystemMock, string.Empty, Encoding.Latin1, "*.generated.cs", false);
 
             // Assert
-            FileSystemMock.Verify(x => x.FileExists(It.IsAny<string>()), Times.Never);
-            FileSystemMock.Verify(x => x.FileDelete(It.IsAny<string>()), Times.Never);
+            FileSystemMock.DidNotReceive().FileExists(Arg.Any<string>());
+            FileSystemMock.DidNotReceive().FileDelete(Arg.Any<string>());
         }
 
         [Fact]
@@ -122,15 +122,15 @@ public partial class MultipleContentBuilderEnvironmentTests
         {
             // Arrange
             var sut = CreateSut();
-            FileSystemMock.Setup(x => x.DirectoryExists(TestData.BasePath)).Returns(true);
-            FileSystemMock.Setup(x => x.GetFiles(TestData.BasePath, "*.generated.cs", false)).Returns(new[] { Path.Combine(TestData.BasePath, "File1.txt") });
+            FileSystemMock.DirectoryExists(TestData.BasePath).Returns(true);
+            FileSystemMock.GetFiles(TestData.BasePath, "*.generated.cs", false).Returns(new[] { Path.Combine(TestData.BasePath, "File1.txt") });
 
             // Act
-            sut.DeleteLastGeneratedFiles(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, "*.generated.cs", false);
+            sut.DeleteLastGeneratedFiles(FileSystemMock, TestData.BasePath, Encoding.Latin1, "*.generated.cs", false);
 
             // Assert
-            FileSystemMock.Verify(x => x.FileExists(It.IsAny<string>()), Times.Never); // not called because the files are read from Directory.GetFiles
-            FileSystemMock.Verify(x => x.FileDelete(It.IsAny<string>()), Times.Once); // called once because Directory.GetFiles returns one file
+            FileSystemMock.DidNotReceive().FileExists(Arg.Any<string>()); // not called because the files are read from Directory.GetFiles
+            FileSystemMock.Received().FileDelete(Arg.Any<string>()); // called once because Directory.GetFiles returns one file
         }
 
         [Fact]
@@ -138,19 +138,19 @@ public partial class MultipleContentBuilderEnvironmentTests
         {
             // Arrange
             var sut = CreateSut();
-            FileSystemMock.Setup(x => x.DirectoryExists(TestData.BasePath)).Returns(true);
-            FileSystemMock.Setup(x => x.GetFiles(TestData.BasePath, "*.generated.cs", true)).Returns(new[]
+            FileSystemMock.DirectoryExists(TestData.BasePath).Returns(true);
+            FileSystemMock.GetFiles(TestData.BasePath, "*.generated.cs", true).Returns(new[]
             {
-            Path.Combine(TestData.BasePath, "File1.txt"),
-            Path.Combine(TestData.BasePath, "Subdirectory", "File2.txt")
-        });
+                Path.Combine(TestData.BasePath, "File1.txt"),
+                Path.Combine(TestData.BasePath, "Subdirectory", "File2.txt")
+            });
 
             // Act
-            sut.DeleteLastGeneratedFiles(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, "*.generated.cs", true);
+            sut.DeleteLastGeneratedFiles(FileSystemMock, TestData.BasePath, Encoding.Latin1, "*.generated.cs", true);
 
             // Assert
-            FileSystemMock.Verify(x => x.FileExists(It.IsAny<string>()), Times.Never); // not called because the files are read from Directory.GetFiles
-            FileSystemMock.Verify(x => x.FileDelete(It.IsAny<string>()), Times.Exactly(2)); // called once because Directory.GetFiles returns two files
+            FileSystemMock.DidNotReceive().FileExists(Arg.Any<string>()); // not called because the files are read from Directory.GetFiles
+            FileSystemMock.Received(2).FileDelete(Arg.Any<string>()); // called once because Directory.GetFiles returns two files
         }
 
         [Fact]
@@ -158,14 +158,14 @@ public partial class MultipleContentBuilderEnvironmentTests
         {
             // Arrange
             var sut = CreateSut();
-            FileSystemMock.Setup(x => x.FileExists("LastGeneratedFiles.txt")).Returns(false);
+            FileSystemMock.FileExists("LastGeneratedFiles.txt").Returns(false);
 
             // Act
-            sut.DeleteLastGeneratedFiles(FileSystemMock.Object, string.Empty, Encoding.Latin1, "LastGeneratedFiles.txt", false);
+            sut.DeleteLastGeneratedFiles(FileSystemMock, string.Empty, Encoding.Latin1, "LastGeneratedFiles.txt", false);
 
             // Assert
-            FileSystemMock.Verify(x => x.FileExists(It.IsAny<string>()), Times.Once); // once because last generated files is checked
-            FileSystemMock.Verify(x => x.FileDelete(It.IsAny<string>()), Times.Never);
+            FileSystemMock.Received().FileExists(Arg.Any<string>()); // once because last generated files is checked
+            FileSystemMock.DidNotReceive().FileDelete(Arg.Any<string>());
         }
 
         [Fact]
@@ -173,19 +173,20 @@ public partial class MultipleContentBuilderEnvironmentTests
         {
             // Arrange
             var sut = CreateSut();
-            FileSystemMock.Setup(x => x.FileExists(It.IsAny<string>())).Returns<string>(path => path == "LastGeneratedFiles.txt" || path == "File1.txt");
-            FileSystemMock.Setup(x => x.ReadAllLines("LastGeneratedFiles.txt", It.IsAny<Encoding>())).Returns(new[]
+            FileSystemMock.FileExists(Arg.Any<string>())
+                          .Returns(x => x.ArgAt<string>(0) == "LastGeneratedFiles.txt" || x.ArgAt<string>(0) == "File1.txt");
+            FileSystemMock.ReadAllLines("LastGeneratedFiles.txt", Arg.Any<Encoding>()).Returns(new[]
             {
-            "File1.txt",
-            "File2.txt"
-        });
+                "File1.txt",
+                "File2.txt"
+            });
 
             // Act
-            sut.DeleteLastGeneratedFiles(FileSystemMock.Object, string.Empty, Encoding.Latin1, "LastGeneratedFiles.txt", false);
+            sut.DeleteLastGeneratedFiles(FileSystemMock, string.Empty, Encoding.Latin1, "LastGeneratedFiles.txt", false);
 
             // Assert
-            FileSystemMock.Verify(x => x.FileExists(It.IsAny<string>()), Times.Exactly(3)); // once because last generated files is checked, two times because of File1.txt and File2.txt
-            FileSystemMock.Verify(x => x.FileDelete(It.IsAny<string>()), Times.Exactly(1)); // File2.txt does not exist, so only File1.txt is deleted
+            FileSystemMock.Received(3).FileExists(Arg.Any<string>()); // once because last generated files is checked, two times because of File1.txt and File2.txt
+            FileSystemMock.Received(1).FileDelete(Arg.Any<string>()); // File2.txt does not exist, so only File1.txt is deleted
         }
 
         [Fact]
@@ -193,19 +194,19 @@ public partial class MultipleContentBuilderEnvironmentTests
         {
             // Arrange
             var sut = CreateSut();
-            FileSystemMock.Setup(x => x.FileExists(It.IsAny<string>())).Returns<string>(path => path == Path.Combine(TestData.BasePath, "LastGeneratedFiles.txt") || path == Path.Combine(TestData.BasePath, "File1.txt"));
-            FileSystemMock.Setup(x => x.ReadAllLines(Path.Combine(TestData.BasePath, "LastGeneratedFiles.txt"), It.IsAny<Encoding>())).Returns(new[]
+            FileSystemMock.FileExists(Arg.Any<string>()).Returns(x => x.ArgAt<string>(0) == Path.Combine(TestData.BasePath, "LastGeneratedFiles.txt") || x.ArgAt<string>(0) == Path.Combine(TestData.BasePath, "File1.txt"));
+            FileSystemMock.ReadAllLines(Path.Combine(TestData.BasePath, "LastGeneratedFiles.txt"), Arg.Any<Encoding>()).Returns(new[]
             {
-            "File1.txt",
-            "File2.txt"
-        });
+                "File1.txt",
+                "File2.txt"
+            });
 
             // Act
-            sut.DeleteLastGeneratedFiles(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, "LastGeneratedFiles.txt", false);
+            sut.DeleteLastGeneratedFiles(FileSystemMock, TestData.BasePath, Encoding.Latin1, "LastGeneratedFiles.txt", false);
 
             // Assert
-            FileSystemMock.Verify(x => x.FileExists(It.IsAny<string>()), Times.Exactly(3)); // once because last generated files is checked, two times because of File1.txt and File2.txt
-            FileSystemMock.Verify(x => x.FileDelete(It.IsAny<string>()), Times.Exactly(1)); // File2.txt does not exist, so only File1.txt is deleted
+            FileSystemMock.Received(3).FileExists(Arg.Any<string>()); // once because last generated files is checked, two times because of File1.txt and File2.txt
+            FileSystemMock.Received(1).FileDelete(Arg.Any<string>()); // File2.txt does not exist, so only File1.txt is deleted
         }
     }
 }

--- a/src/Core.Tests/GenerationEnvironments/MultipleContentBuilderEnvironment/MultipleContentBuilderEnvironmentTests.SaveAll.cs
+++ b/src/Core.Tests/GenerationEnvironments/MultipleContentBuilderEnvironment/MultipleContentBuilderEnvironmentTests.SaveAll.cs
@@ -11,11 +11,11 @@ public partial class MultipleContentBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act
-            sut.SaveAll(FileSystemMock.Object, string.Empty, Encoding.Latin1, CreateContents());
+            sut.SaveAll(FileSystemMock, string.Empty, Encoding.Latin1, CreateContents());
 
             // Assert
-            FileSystemMock.Verify(x => x.WriteAllText("File1.txt", "Test1" + Environment.NewLine, Encoding.Latin1), Times.Once);
-            FileSystemMock.Verify(x => x.WriteAllText("File2.txt", "Test2" + Environment.NewLine, Encoding.Latin1), Times.Once);
+            FileSystemMock.Received().WriteAllText("File1.txt", "Test1" + Environment.NewLine, Encoding.Latin1);
+            FileSystemMock.Received().WriteAllText("File2.txt", "Test2" + Environment.NewLine, Encoding.Latin1);
         }
 
         [Fact]
@@ -29,10 +29,10 @@ public partial class MultipleContentBuilderEnvironmentTests
             var contents = builder.Build().Contents;
 
             // Act
-            sut.SaveAll(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, contents);
+            sut.SaveAll(FileSystemMock, TestData.BasePath, Encoding.Latin1, contents);
 
             // Assert
-            FileSystemMock.Verify(x => x.WriteAllText(Path.Combine(TestData.BasePath, "File1.txt"), "Test1" + Environment.NewLine, Encoding.Latin1), Times.Once);
+            FileSystemMock.Received().WriteAllText(Path.Combine(TestData.BasePath, "File1.txt"), "Test1" + Environment.NewLine, Encoding.Latin1);
         }
 
         [Fact]
@@ -42,11 +42,11 @@ public partial class MultipleContentBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act
-            sut.SaveAll(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, CreateContents());
+            sut.SaveAll(FileSystemMock, TestData.BasePath, Encoding.Latin1, CreateContents());
 
             // Assert
-            FileSystemMock.Verify(x => x.WriteAllText(Path.Combine(TestData.BasePath, "File1.txt"), "Test1" + Environment.NewLine, Encoding.Latin1), Times.Once);
-            FileSystemMock.Verify(x => x.WriteAllText(Path.Combine(TestData.BasePath, "File2.txt"), "Test2" + Environment.NewLine, Encoding.Latin1), Times.Once);
+            FileSystemMock.Received().WriteAllText(Path.Combine(TestData.BasePath, "File1.txt"), "Test1" + Environment.NewLine, Encoding.Latin1);
+            FileSystemMock.Received().WriteAllText(Path.Combine(TestData.BasePath, "File2.txt"), "Test2" + Environment.NewLine, Encoding.Latin1);
         }
 
         [Fact]
@@ -56,7 +56,7 @@ public partial class MultipleContentBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.SaveAll(FileSystemMock.Object, TestData.BasePath, encoding: null!, CreateContents()))
+            sut.Invoking(x => x.SaveAll(FileSystemMock, TestData.BasePath, encoding: null!, CreateContents()))
                .Should().Throw<ArgumentNullException>().WithParameterName("encoding");
         }
 
@@ -70,13 +70,13 @@ public partial class MultipleContentBuilderEnvironmentTests
             c1.Builder.AppendLine("Test1");
             var contents = builder.Build().Contents;
 
-            FileSystemMock.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
+            FileSystemMock.FileExists(Arg.Any<string>()).Returns(true);
 
             // Act
-            sut.SaveAll(FileSystemMock.Object, string.Empty, Encoding.Latin1, contents);
+            sut.SaveAll(FileSystemMock, string.Empty, Encoding.Latin1, contents);
 
             // Assert
-            FileSystemMock.Verify(x => x.WriteAllText(It.IsAny<string>(), It.IsAny<string>(), Encoding.Latin1), Times.Never);
+            FileSystemMock.DidNotReceive().WriteAllText(Arg.Any<string>(), Arg.Any<string>(), Encoding.Latin1);
         }
 
         [Fact]
@@ -85,17 +85,17 @@ public partial class MultipleContentBuilderEnvironmentTests
             // Arrange
             var sut = CreateSut();
             int counter = 0;
-            FileSystemMock.Setup(x => x.DirectoryExists(TestData.BasePath)).Returns(() =>
+            FileSystemMock.DirectoryExists(TestData.BasePath).Returns(_ =>
             {
                 counter++;
                 return counter == 1;
             });
 
             // Act
-            sut.SaveAll(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, CreateContents());
+            sut.SaveAll(FileSystemMock, TestData.BasePath, Encoding.Latin1, CreateContents());
 
             // Assert
-            FileSystemMock.Verify(x => x.CreateDirectory(TestData.BasePath), Times.Once);
+            FileSystemMock.Received().CreateDirectory(TestData.BasePath);
         }
 
         [Fact]
@@ -105,11 +105,11 @@ public partial class MultipleContentBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act
-            sut.SaveAll(FileSystemMock.Object, TestData.BasePath, Encoding.UTF32, CreateContents());
+            sut.SaveAll(FileSystemMock, TestData.BasePath, Encoding.UTF32, CreateContents());
 
             // Assert
-            FileSystemMock.Verify(x => x.WriteAllText(Path.Combine(TestData.BasePath, "File1.txt"), "Test1" + Environment.NewLine, Encoding.UTF32), Times.Once);
-            FileSystemMock.Verify(x => x.WriteAllText(Path.Combine(TestData.BasePath, "File2.txt"), "Test2" + Environment.NewLine, Encoding.UTF32), Times.Once);
+            FileSystemMock.Received().WriteAllText(Path.Combine(TestData.BasePath, "File1.txt"), "Test1" + Environment.NewLine, Encoding.UTF32);
+            FileSystemMock.Received().WriteAllText(Path.Combine(TestData.BasePath, "File2.txt"), "Test2" + Environment.NewLine, Encoding.UTF32);
         }
 
         [Fact]
@@ -118,10 +118,10 @@ public partial class MultipleContentBuilderEnvironmentTests
             // Arrange
             var sut = CreateSut();
             int attempt = 0;
-            FileSystemMock.Setup(x => x.WriteAllText(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Encoding>()))
-                          .Callback<string, string, Encoding>((path, contents, encoding) =>
+            FileSystemMock.When(x => x.WriteAllText(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Encoding>()))
+                          .Do(x =>
                           {
-                              if (path == Path.Combine(TestData.BasePath, "File1.txt"))
+                              if (x.ArgAt<string>(0) == Path.Combine(TestData.BasePath, "File1.txt"))
                               {
                                   attempt++;
                                   if (attempt < 3)
@@ -131,11 +131,11 @@ public partial class MultipleContentBuilderEnvironmentTests
                               }
                           });
             // Act
-            sut.SaveAll(FileSystemMock.Object, TestData.BasePath, Encoding.UTF32, CreateContents());
+            sut.SaveAll(FileSystemMock, TestData.BasePath, Encoding.UTF32, CreateContents());
 
             // Assert
-            FileSystemMock.Verify(x => x.WriteAllText(Path.Combine(TestData.BasePath, "File1.txt"), "Test1" + Environment.NewLine, Encoding.UTF32), Times.Exactly(3));
-            FileSystemMock.Verify(x => x.WriteAllText(Path.Combine(TestData.BasePath, "File2.txt"), "Test2" + Environment.NewLine, Encoding.UTF32), Times.Once);
+            FileSystemMock.Received(3).WriteAllText(Path.Combine(TestData.BasePath, "File1.txt"), "Test1" + Environment.NewLine, Encoding.UTF32);
+            FileSystemMock.Received().WriteAllText(Path.Combine(TestData.BasePath, "File2.txt"), "Test2" + Environment.NewLine, Encoding.UTF32);
         }
     }
 }

--- a/src/Core.Tests/GenerationEnvironments/MultipleContentBuilderEnvironment/MultipleContentBuilderEnvironmentTests.SaveContents.cs
+++ b/src/Core.Tests/GenerationEnvironments/MultipleContentBuilderEnvironment/MultipleContentBuilderEnvironmentTests.SaveContents.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests.GenerationEnvironments;
+namespace TemplateFramework.Core.Tests.GenerationEnvironments;
 
 public partial class MultipleContentBuilderEnvironmentTests
 {
@@ -6,13 +6,13 @@ public partial class MultipleContentBuilderEnvironmentTests
     {
         public SaveContents()
         {
-            CodeGenerationProviderMock.SetupGet(x => x.LastGeneratedFilesFilename).Returns("LastGeneratedFiles.txt");
-            CodeGenerationProviderMock.SetupGet(x => x.Encoding).Returns(Encoding.Latin1);
-            CodeGenerationProviderMock.SetupGet(x => x.Path).Returns("Subdirectory");
-            ContentMock.SetupGet(x => x.Filename).Returns(Path.Combine("Subdirectory", "Filename.txt"));
-            ContentMock.SetupGet(x => x.Contents).Returns("Content");
-            MultipleContentMock.SetupGet(x => x.Contents).Returns(new[] { ContentMock.Object }.ToList().AsReadOnly());
-            MultipleContentBuilderMock.Setup(x => x.Build()).Returns(MultipleContentMock.Object);
+            CodeGenerationProviderMock.LastGeneratedFilesFilename.Returns("LastGeneratedFiles.txt");
+            CodeGenerationProviderMock.Encoding.Returns(Encoding.Latin1);
+            CodeGenerationProviderMock.Path.Returns("Subdirectory");
+            ContentMock.Filename.Returns(Path.Combine("Subdirectory", "Filename.txt"));
+            ContentMock.Contents.Returns("Content");
+            MultipleContentMock.Contents.Returns(new[] { ContentMock }.ToList().AsReadOnly());
+            MultipleContentBuilderMock.Build().Returns(MultipleContentMock);
         }
 
         [Fact]
@@ -20,13 +20,13 @@ public partial class MultipleContentBuilderEnvironmentTests
         {
             // Arrange
             var sut = CreateSut();
-            FileSystemMock.Setup(x => x.FileExists(Path.Combine(TestData.BasePath, "Subdirectory", "LastGeneratedFiles.txt"))).Returns(true);
+            FileSystemMock.FileExists(Path.Combine(TestData.BasePath, "Subdirectory", "LastGeneratedFiles.txt")).Returns(true);
 
             // Act
-            sut.SaveContents(CodeGenerationProviderMock.Object, TestData.BasePath, string.Empty);
+            sut.SaveContents(CodeGenerationProviderMock, TestData.BasePath, string.Empty);
 
             // Assert
-            FileSystemMock.Verify(x => x.ReadAllLines(Path.Combine(TestData.BasePath, "Subdirectory", "LastGeneratedFiles.txt"), Encoding.Latin1), Times.Once);
+            FileSystemMock.Received().ReadAllLines(Path.Combine(TestData.BasePath, "Subdirectory", "LastGeneratedFiles.txt"), Encoding.Latin1);
         }
 
         [Fact]
@@ -34,13 +34,13 @@ public partial class MultipleContentBuilderEnvironmentTests
         {
             // Arrange
             var sut = CreateSut();
-            CodeGenerationProviderMock.SetupGet(x => x.LastGeneratedFilesFilename).Returns(default(string)!);
+            CodeGenerationProviderMock.LastGeneratedFilesFilename.Returns(default(string)!);
 
             // Act
-            sut.SaveContents(CodeGenerationProviderMock.Object, TestData.BasePath, string.Empty);
+            sut.SaveContents(CodeGenerationProviderMock, TestData.BasePath, string.Empty);
 
             // Assert
-            FileSystemMock.Verify(x => x.ReadAllLines(It.IsAny<string>(), It.IsAny<Encoding>()), Times.Never);
+            FileSystemMock.DidNotReceive().ReadAllLines(Arg.Any<string>(), Arg.Any<Encoding>());
         }
 
         [Fact]
@@ -48,13 +48,13 @@ public partial class MultipleContentBuilderEnvironmentTests
         {
             // Arrange
             var sut = CreateSut();
-            CodeGenerationProviderMock.SetupGet(x => x.LastGeneratedFilesFilename).Returns(string.Empty);
+            CodeGenerationProviderMock.LastGeneratedFilesFilename.Returns(string.Empty);
 
             // Act
-            sut.SaveContents(CodeGenerationProviderMock.Object, TestData.BasePath, string.Empty);
+            sut.SaveContents(CodeGenerationProviderMock, TestData.BasePath, string.Empty);
 
             // Assert
-            FileSystemMock.Verify(x => x.ReadAllLines(It.IsAny<string>(), It.IsAny<Encoding>()), Times.Never);
+            FileSystemMock.DidNotReceive().ReadAllLines(Arg.Any<string>(), Arg.Any<Encoding>());
         }
 
         [Fact]
@@ -64,10 +64,10 @@ public partial class MultipleContentBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act
-            sut.SaveContents(CodeGenerationProviderMock.Object, TestData.BasePath, string.Empty);
+            sut.SaveContents(CodeGenerationProviderMock, TestData.BasePath, string.Empty);
 
             // Assert
-            FileSystemMock.Verify(x => x.WriteAllText(Path.Combine(TestData.BasePath, "Subdirectory", "Filename.txt"), "Content", Encoding.Latin1), Times.Once);
+            FileSystemMock.Received().WriteAllText(Path.Combine(TestData.BasePath, "Subdirectory", "Filename.txt"), "Content", Encoding.Latin1);
         }
     }
 }

--- a/src/Core.Tests/GenerationEnvironments/MultipleContentBuilderEnvironment/MultipleContentBuilderEnvironmentTests.SaveLastGeneratedFiles.cs
+++ b/src/Core.Tests/GenerationEnvironments/MultipleContentBuilderEnvironment/MultipleContentBuilderEnvironmentTests.SaveLastGeneratedFiles.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests.GenerationEnvironments;
+namespace TemplateFramework.Core.Tests.GenerationEnvironments;
 
 public partial class MultipleContentBuilderEnvironmentTests
 {
@@ -11,7 +11,7 @@ public partial class MultipleContentBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.SaveLastGeneratedFiles(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, lastGeneratedFilesPath: null!, CreateContents() ))
+            sut.Invoking(x => x.SaveLastGeneratedFiles(FileSystemMock, TestData.BasePath, Encoding.Latin1, lastGeneratedFilesPath: null!, CreateContents() ))
                .Should().Throw<ArgumentNullException>().WithParameterName("lastGeneratedFilesPath");
         }
 
@@ -22,7 +22,7 @@ public partial class MultipleContentBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.SaveLastGeneratedFiles(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, lastGeneratedFilesPath: string.Empty, CreateContents()))
+            sut.Invoking(x => x.SaveLastGeneratedFiles(FileSystemMock, TestData.BasePath, Encoding.Latin1, lastGeneratedFilesPath: string.Empty, CreateContents()))
                .Should().Throw<ArgumentException>().WithParameterName("lastGeneratedFilesPath");
         }
 
@@ -33,7 +33,7 @@ public partial class MultipleContentBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.SaveLastGeneratedFiles(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, lastGeneratedFilesPath: " ", CreateContents()))
+            sut.Invoking(x => x.SaveLastGeneratedFiles(FileSystemMock, TestData.BasePath, Encoding.Latin1, lastGeneratedFilesPath: " ", CreateContents()))
                .Should().Throw<ArgumentException>().WithParameterName("lastGeneratedFilesPath");
         }
 
@@ -44,7 +44,7 @@ public partial class MultipleContentBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.SaveLastGeneratedFiles(FileSystemMock.Object, TestData.BasePath, encoding: null!, "LastGeneratedFiles.txt", CreateContents()))
+            sut.Invoking(x => x.SaveLastGeneratedFiles(FileSystemMock, TestData.BasePath, encoding: null!, "LastGeneratedFiles.txt", CreateContents()))
                .Should().Throw<ArgumentNullException>().WithParameterName("encoding");
         }
 
@@ -55,7 +55,7 @@ public partial class MultipleContentBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.SaveLastGeneratedFiles(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, "LastGeneratedFiles.txt", contents: null!))
+            sut.Invoking(x => x.SaveLastGeneratedFiles(FileSystemMock, TestData.BasePath, Encoding.Latin1, "LastGeneratedFiles.txt", contents: null!))
                .Should().Throw<ArgumentNullException>().WithParameterName("contents");
         }
 
@@ -64,13 +64,13 @@ public partial class MultipleContentBuilderEnvironmentTests
         {
             // Arrange
             var sut = CreateSut();
-            FileSystemMock.Setup(x => x.DirectoryExists(TestData.BasePath)).Returns(false);
+            FileSystemMock.DirectoryExists(TestData.BasePath).Returns(false);
 
             // Act
-            sut.SaveLastGeneratedFiles(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, "LastGeneratedFiles.txt", CreateContents());
+            sut.SaveLastGeneratedFiles(FileSystemMock, TestData.BasePath, Encoding.Latin1, "LastGeneratedFiles.txt", CreateContents());
 
             // Assert
-            FileSystemMock.Verify(x => x.CreateDirectory(TestData.BasePath), Times.Once);
+            FileSystemMock.Received().CreateDirectory(TestData.BasePath);
         }
 
         [Fact]
@@ -78,13 +78,13 @@ public partial class MultipleContentBuilderEnvironmentTests
         {
             // Arrange
             var sut = CreateSut();
-            FileSystemMock.Setup(x => x.DirectoryExists(TestData.BasePath)).Returns(true);
+            FileSystemMock.DirectoryExists(TestData.BasePath).Returns(true);
 
             // Act
-            sut.SaveLastGeneratedFiles(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, "LastGeneratedFiles.txt", CreateContents());
+            sut.SaveLastGeneratedFiles(FileSystemMock, TestData.BasePath, Encoding.Latin1, "LastGeneratedFiles.txt", CreateContents());
 
             // Assert
-            FileSystemMock.Verify(x => x.WriteAllLines(Path.Combine(TestData.BasePath, "LastGeneratedFiles.txt"), It.IsAny<IEnumerable<string>>(), Encoding.Latin1), Times.Once);
+            FileSystemMock.Received().WriteAllLines(Path.Combine(TestData.BasePath, "LastGeneratedFiles.txt"), Arg.Any<IEnumerable<string>>(), Encoding.Latin1);
         }
 
         [Fact]
@@ -92,13 +92,13 @@ public partial class MultipleContentBuilderEnvironmentTests
         {
             // Arrange
             var sut = CreateSut();
-            FileSystemMock.Setup(x => x.DirectoryExists("MyDirectory")).Returns(true);
+            FileSystemMock.DirectoryExists("MyDirectory").Returns(true);
 
             // Act
-            sut.SaveLastGeneratedFiles(FileSystemMock.Object, string.Empty, Encoding.Latin1, "LastGeneratedFiles.txt", CreateContents());
+            sut.SaveLastGeneratedFiles(FileSystemMock, string.Empty, Encoding.Latin1, "LastGeneratedFiles.txt", CreateContents());
 
             // Assert
-            FileSystemMock.Verify(x => x.WriteAllLines("LastGeneratedFiles.txt", It.IsAny<IEnumerable<string>>(), Encoding.Latin1), Times.Once);
+            FileSystemMock.Received().WriteAllLines("LastGeneratedFiles.txt", Arg.Any<IEnumerable<string>>(), Encoding.Latin1);
         }
 
         [Fact]
@@ -106,13 +106,13 @@ public partial class MultipleContentBuilderEnvironmentTests
         {
             // Arrange
             var sut = CreateSut();
-            FileSystemMock.Setup(x => x.DirectoryExists(TestData.BasePath)).Returns(true);
+            FileSystemMock.DirectoryExists(TestData.BasePath).Returns(true);
 
             // Act
-            sut.SaveLastGeneratedFiles(FileSystemMock.Object, TestData.BasePath, Encoding.Latin1, "*.template.generated.cs", CreateContents());
+            sut.SaveLastGeneratedFiles(FileSystemMock, TestData.BasePath, Encoding.Latin1, "*.template.generated.cs", CreateContents());
 
             // Assert
-            FileSystemMock.Verify(x => x.WriteAllLines(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), Encoding.Latin1), Times.Never);
+            FileSystemMock.DidNotReceive().WriteAllLines(Arg.Any<string>(), Arg.Any<IEnumerable<string>>(), Encoding.Latin1);
         }
     }
 }

--- a/src/Core.Tests/GenerationEnvironments/MultipleContentBuilderEnvironment/MultipleContentBuilderEnvironmentTests.cs
+++ b/src/Core.Tests/GenerationEnvironments/MultipleContentBuilderEnvironment/MultipleContentBuilderEnvironmentTests.cs
@@ -2,14 +2,14 @@
 
 public partial class MultipleContentBuilderEnvironmentTests
 {
-    protected Mock<IFileSystem> FileSystemMock { get; } = new();
-    protected Mock<ICodeGenerationProvider> CodeGenerationProviderMock { get; } = new();
-    protected Mock<IMultipleContentBuilder> MultipleContentBuilderMock { get; } = new();
-    protected Mock<IMultipleContent> MultipleContentMock { get; } = new();
-    protected Mock<IContent> ContentMock { get; } = new();
+    protected IFileSystem FileSystemMock { get; } = Substitute.For<IFileSystem>();
+    protected ICodeGenerationProvider CodeGenerationProviderMock { get; } = Substitute.For<ICodeGenerationProvider>();
+    protected IMultipleContentBuilder MultipleContentBuilderMock { get; } = Substitute.For<IMultipleContentBuilder>();
+    protected IMultipleContent MultipleContentMock { get; } = Substitute.For<IMultipleContent>();
+    protected IContent ContentMock { get; } = Substitute.For<IContent>();
     protected IRetryMechanism RetryMechanism { get; } = new FastRetryMechanism();
 
-    protected MultipleContentBuilderEnvironment CreateSut() => new(FileSystemMock.Object, RetryMechanism, MultipleContentBuilderMock.Object);
+    protected MultipleContentBuilderEnvironment CreateSut() => new(FileSystemMock, RetryMechanism, MultipleContentBuilderMock);
 
     protected IEnumerable<IContent> CreateContents(bool skipWhenFileExists = false)
     {

--- a/src/Core.Tests/GenerationEnvironments/StringBuilderEnvironment/StringBuilderEnvironmentTests.Constructor.cs
+++ b/src/Core.Tests/GenerationEnvironments/StringBuilderEnvironment/StringBuilderEnvironmentTests.Constructor.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests.GenerationEnvironments;
+namespace TemplateFramework.Core.Tests.GenerationEnvironments;
 
 public partial class StringBuilderEnvironmentTests
 {
@@ -8,7 +8,7 @@ public partial class StringBuilderEnvironmentTests
         public void Throws_On_Null_Builder()
         {
             // Act & Assert
-            this.Invoking(_ => new StringBuilderEnvironment(FileSystemMock.Object, builder: null!))
+            this.Invoking(_ => new StringBuilderEnvironment(FileSystemMock, builder: null!))
                 .Should().Throw<ArgumentNullException>().WithParameterName("builder");
         }
 

--- a/src/Core.Tests/GenerationEnvironments/StringBuilderEnvironment/StringBuilderEnvironmentTests.SaveContents.cs
+++ b/src/Core.Tests/GenerationEnvironments/StringBuilderEnvironment/StringBuilderEnvironmentTests.SaveContents.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests.GenerationEnvironments;
+namespace TemplateFramework.Core.Tests.GenerationEnvironments;
 
 public partial class StringBuilderEnvironmentTests
 {
@@ -22,7 +22,7 @@ public partial class StringBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.SaveContents(CodeGenerationProviderMock.Object, TestData.BasePath, defaultFilename: null!))
+            sut.Invoking(x => x.SaveContents(CodeGenerationProviderMock, TestData.BasePath, defaultFilename: null!))
                .Should().Throw<ArgumentException>().WithParameterName("defaultFilename");
         }
 
@@ -33,7 +33,7 @@ public partial class StringBuilderEnvironmentTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.SaveContents(CodeGenerationProviderMock.Object, TestData.BasePath, defaultFilename: string.Empty))
+            sut.Invoking(x => x.SaveContents(CodeGenerationProviderMock, TestData.BasePath, defaultFilename: string.Empty))
                .Should().Throw<ArgumentException>().WithParameterName("defaultFilename");
         }
 
@@ -42,14 +42,14 @@ public partial class StringBuilderEnvironmentTests
         {
             // Arrange
             var sut = CreateSut();
-            CodeGenerationProviderMock.SetupGet(x => x.Encoding).Returns(Encoding.UTF32);
+            CodeGenerationProviderMock.Encoding.Returns(Encoding.UTF32);
             Builder.Append("Contents");
 
             // Act
-            sut.SaveContents(CodeGenerationProviderMock.Object, string.Empty, "Filename.txt");
+            sut.SaveContents(CodeGenerationProviderMock, string.Empty, "Filename.txt");
 
             // Arrange
-            FileSystemMock.Verify(x => x.WriteAllText("Filename.txt", "Contents", Encoding.UTF32), Times.Once);
+            FileSystemMock.Received().WriteAllText("Filename.txt", "Contents", Encoding.UTF32);
         }
 
         [Fact]
@@ -57,14 +57,14 @@ public partial class StringBuilderEnvironmentTests
         {
             // Arrange
             var sut = CreateSut();
-            CodeGenerationProviderMock.SetupGet(x => x.Encoding).Returns(Encoding.UTF32);
+            CodeGenerationProviderMock.Encoding.Returns(Encoding.UTF32);
             Builder.Append("Contents");
 
             // Act
-            sut.SaveContents(CodeGenerationProviderMock.Object, TestData.BasePath, "Filename.txt");
+            sut.SaveContents(CodeGenerationProviderMock, TestData.BasePath, "Filename.txt");
 
             // Arrange
-            FileSystemMock.Verify(x => x.WriteAllText(Path.Combine(TestData.BasePath, "Filename.txt"), "Contents", Encoding.UTF32), Times.Once);
+            FileSystemMock.Received().WriteAllText(Path.Combine(TestData.BasePath, "Filename.txt"), "Contents", Encoding.UTF32);
         }
     }
 }

--- a/src/Core.Tests/GenerationEnvironments/StringBuilderEnvironment/StringBuilderEnvironmentTests.cs
+++ b/src/Core.Tests/GenerationEnvironments/StringBuilderEnvironment/StringBuilderEnvironmentTests.cs
@@ -2,9 +2,9 @@
 
 public partial class StringBuilderEnvironmentTests
 {
-    protected Mock<IFileSystem> FileSystemMock { get; } = new();
-    protected Mock<ICodeGenerationProvider> CodeGenerationProviderMock { get; } = new();
+    protected IFileSystem FileSystemMock { get; } = Substitute.For<IFileSystem>();
+    protected ICodeGenerationProvider CodeGenerationProviderMock { get; } = Substitute.For<ICodeGenerationProvider>();
     protected StringBuilder Builder { get; } = new();
     
-    protected StringBuilderEnvironment CreateSut() => new(FileSystemMock.Object, Builder);
+    protected StringBuilderEnvironment CreateSut() => new(FileSystemMock, Builder);
 }

--- a/src/Core.Tests/IntegrationTests.cs
+++ b/src/Core.Tests/IntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests;
+namespace TemplateFramework.Core.Tests;
 
 public class IntegrationTests
 {
@@ -8,7 +8,7 @@ public class IntegrationTests
         // Arrange
         using var provider = new ServiceCollection()
             .AddTemplateFramework()
-            .AddSingleton(new Mock<ITemplateComponentRegistryPluginFactory>().Object)
+            .AddSingleton(Substitute.For<ITemplateComponentRegistryPluginFactory>())
             .BuildServiceProvider(true);
         using var scope = provider.CreateScope();
         var sut = scope.ServiceProvider.GetRequiredService<ITemplateEngine>();

--- a/src/Core.Tests/MultipleContentBuilderTemplateCreators/TypedMultipleCreator/TypedMultipleCreatorTests.TryCreate.cs
+++ b/src/Core.Tests/MultipleContentBuilderTemplateCreators/TypedMultipleCreator/TypedMultipleCreatorTests.TryCreate.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests.MultipleContentBuilderTemplateCreators;
+namespace TemplateFramework.Core.Tests.MultipleContentBuilderTemplateCreators;
 
 public partial class TypedMultipleCreatorTests
 {
@@ -8,14 +8,14 @@ public partial class TypedMultipleCreatorTests
         public void Returns_Instance_When_Instance_Is_Assignable_To_IMultipleContentBuilderTemplate()
         {
             // Arrange
-            var templateMock = new Mock<IMultipleContentBuilderTemplate>();
+            var templateMock = Substitute.For<IMultipleContentBuilderTemplate>();
             var sut = CreateSut();
 
             // Act
-            var result = sut.TryCreate(templateMock.Object);
+            var result = sut.TryCreate(templateMock);
 
             // Assert
-            result.Should().BeSameAs(templateMock.Object);
+            result.Should().BeSameAs(templateMock);
         }
 
         [Fact]

--- a/src/Core.Tests/Requests/RenderTemplateRequestTests.Typed.cs
+++ b/src/Core.Tests/Requests/RenderTemplateRequestTests.Typed.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests.Requests;
+namespace TemplateFramework.Core.Tests.Requests;
 
 public partial class RenderTemplateRequestTests
 {
@@ -240,7 +240,7 @@ public partial class RenderTemplateRequestTests
         public void Constructs_Using_MultipleContentBuilder_1()
         {
             // Act & Assert
-            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), null, builder: MultipleContentBuilderMock.Object, defaultFilename: DefaultFilename, additionalParameters: null, context: null))
+            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), null, builder: MultipleContentBuilderMock, defaultFilename: DefaultFilename, additionalParameters: null, context: null))
                 .Should().NotThrow();
         }
 
@@ -256,7 +256,7 @@ public partial class RenderTemplateRequestTests
         public void Constructs_Using_MultipleContentBuilder_2()
         {
             // Act & Assert
-            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), null, builder: MultipleContentBuilderMock.Object))
+            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), null, builder: MultipleContentBuilderMock))
                 .Should().NotThrow();
         }
 
@@ -272,7 +272,7 @@ public partial class RenderTemplateRequestTests
         public void Constructs_Using_MultipleContentBuilder_3()
         {
             // Act & Assert
-            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), null, builder: MultipleContentBuilderMock.Object, defaultFilename: DefaultFilename))
+            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), null, builder: MultipleContentBuilderMock, defaultFilename: DefaultFilename))
                 .Should().NotThrow();
         }
 
@@ -288,7 +288,7 @@ public partial class RenderTemplateRequestTests
         public void Constructs_Using_MultipleContentBuilder_4()
         {
             // Act & Assert
-            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), null, builder: MultipleContentBuilderMock.Object, defaultFilename: DefaultFilename, additionalParameters: null))
+            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), null, builder: MultipleContentBuilderMock, defaultFilename: DefaultFilename, additionalParameters: null))
                 .Should().NotThrow();
         }
 
@@ -304,7 +304,7 @@ public partial class RenderTemplateRequestTests
         public void Constructs_Using_MultipleContentBuilder_5()
         {
             // Act & Assert
-            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), null, builder: MultipleContentBuilderMock.Object, additionalParameters: null))
+            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), null, builder: MultipleContentBuilderMock, additionalParameters: null))
                 .Should().NotThrow();
         }
 
@@ -320,7 +320,7 @@ public partial class RenderTemplateRequestTests
         public void Constructs_Using_MultipleContentBuilder_6()
         {
             // Act & Assert
-            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), null, builder: MultipleContentBuilderMock.Object, defaultFilename: DefaultFilename, context: null))
+            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), null, builder: MultipleContentBuilderMock, defaultFilename: DefaultFilename, context: null))
                 .Should().NotThrow();
         }
 
@@ -336,7 +336,7 @@ public partial class RenderTemplateRequestTests
         public void Constructs_Using_MultipleContentBuilder_7()
         {
             // Act & Assert
-            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), null, builder: MultipleContentBuilderMock.Object, context: null))
+            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), null, builder: MultipleContentBuilderMock, context: null))
                 .Should().NotThrow();
         }
 
@@ -352,7 +352,7 @@ public partial class RenderTemplateRequestTests
         public void Constructs_Using_MultipleContentBuilder_8()
         {
             // Act & Assert
-            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), builder: MultipleContentBuilderMock.Object, defaultFilename: DefaultFilename, additionalParameters: null, context: null))
+            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), builder: MultipleContentBuilderMock, defaultFilename: DefaultFilename, additionalParameters: null, context: null))
                 .Should().NotThrow();
         }
 
@@ -368,7 +368,7 @@ public partial class RenderTemplateRequestTests
         public void Constructs_Using_MultipleContentBuilder_9()
         {
             // Act & Assert
-            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), builder: MultipleContentBuilderMock.Object))
+            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), builder: MultipleContentBuilderMock))
                 .Should().NotThrow();
         }
 
@@ -384,7 +384,7 @@ public partial class RenderTemplateRequestTests
         public void Constructs_Using_MultipleContentBuilder_10()
         {
             // Act & Assert
-            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), builder: MultipleContentBuilderMock.Object, defaultFilename: DefaultFilename))
+            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), builder: MultipleContentBuilderMock, defaultFilename: DefaultFilename))
                 .Should().NotThrow();
         }
 
@@ -400,7 +400,7 @@ public partial class RenderTemplateRequestTests
         public void Constructs_Using_MultipleContentBuilder_11()
         {
             // Act & Assert
-            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), builder: MultipleContentBuilderMock.Object, defaultFilename: DefaultFilename, additionalParameters: null))
+            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), builder: MultipleContentBuilderMock, defaultFilename: DefaultFilename, additionalParameters: null))
                 .Should().NotThrow();
         }
 
@@ -416,7 +416,7 @@ public partial class RenderTemplateRequestTests
         public void Constructs_Using_MultipleContentBuilder_12()
         {
             // Act & Assert
-            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), builder: MultipleContentBuilderMock.Object, additionalParameters: null))
+            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), builder: MultipleContentBuilderMock, additionalParameters: null))
                 .Should().NotThrow();
         }
 
@@ -432,7 +432,7 @@ public partial class RenderTemplateRequestTests
         public void Constructs_Using_MultipleContentBuilder_13()
         {
             // Act & Assert
-            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), builder: MultipleContentBuilderMock.Object, defaultFilename: DefaultFilename, context: null))
+            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), builder: MultipleContentBuilderMock, defaultFilename: DefaultFilename, context: null))
                 .Should().NotThrow();
         }
 
@@ -448,7 +448,7 @@ public partial class RenderTemplateRequestTests
         public void Constructs_Using_MultipleContentBuilder_14()
         {
             // Act & Assert
-            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), builder: MultipleContentBuilderMock.Object, context: null))
+            this.Invoking(_ => new RenderTemplateRequest(new TemplateInstanceIdentifier(this), builder: MultipleContentBuilderMock, context: null))
                 .Should().NotThrow();
         }
 
@@ -480,16 +480,16 @@ public partial class RenderTemplateRequestTests
         public void Fills_All_Properties_Correclty_When_Instanciating_Using_GenerationEnvironment()
         {
             // Act
-            var instance = new RenderTemplateRequest(new TemplateInstanceIdentifier(this), "Hello world", GenerationEnvironmentMock.Object, DefaultFilename, AdditionalParameters, TemplateContextMock.Object);
+            var instance = new RenderTemplateRequest(new TemplateInstanceIdentifier(this), "Hello world", GenerationEnvironmentMock, DefaultFilename, AdditionalParameters, TemplateContextMock);
 
             // Assert
             instance.Should().NotBeNull();
             instance.Identifier.Should().BeOfType<TemplateInstanceIdentifier>().And.Match<TemplateInstanceIdentifier>(x => x.Instance == this);
             instance.Model.Should().Be("Hello world");
-            instance.GenerationEnvironment.Should().BeSameAs(GenerationEnvironmentMock.Object);
+            instance.GenerationEnvironment.Should().BeSameAs(GenerationEnvironmentMock);
             instance.DefaultFilename.Should().Be(DefaultFilename);
             instance.AdditionalParameters.Should().BeSameAs(AdditionalParameters);
-            instance.Context.Should().BeSameAs(TemplateContextMock.Object);
+            instance.Context.Should().BeSameAs(TemplateContextMock);
         }
     }
 }

--- a/src/Core.Tests/Requests/RenderTemplateRequestTests.cs
+++ b/src/Core.Tests/Requests/RenderTemplateRequestTests.cs
@@ -3,9 +3,9 @@
 public partial class RenderTemplateRequestTests
 {
     protected StringBuilder StringBuilder { get; } = new();
-    protected Mock<IMultipleContentBuilder> MultipleContentBuilderMock { get; } = new();
-    protected Mock<IGenerationEnvironment> GenerationEnvironmentMock { get; } = new();
-    protected Mock<ITemplateContext> TemplateContextMock { get; } = new();
+    protected IMultipleContentBuilder MultipleContentBuilderMock { get; } = Substitute.For<IMultipleContentBuilder>();
+    protected IGenerationEnvironment GenerationEnvironmentMock { get; } = Substitute.For<IGenerationEnvironment>();
+    protected ITemplateContext TemplateContextMock { get; } = Substitute.For<ITemplateContext>();
 
     protected const string DefaultFilename = "MyFile.txt";
     protected object AdditionalParameters { get; } = new object();

--- a/src/Core.Tests/StringBuilderTemplateRenderers/TypedStringBuilderTemplateRendererTests.cs
+++ b/src/Core.Tests/StringBuilderTemplateRenderers/TypedStringBuilderTemplateRendererTests.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests.StringBuilderTemplateRenderers;
+namespace TemplateFramework.Core.Tests.StringBuilderTemplateRenderers;
 
 public class TypedStringBuilderTemplateRendererTests
 {
@@ -33,10 +33,10 @@ public class TypedStringBuilderTemplateRendererTests
     {
         // Arrange
         var sut = new TypedStringBuilderTemplateRenderer();
-        var templateMock = new Mock<IStringBuilderTemplate>();
+        var templateMock = Substitute.For<IStringBuilderTemplate>();
 
         // Act
-        var result = sut.TryRender(instance: templateMock.Object, new StringBuilder());
+        var result = sut.TryRender(instance: templateMock, new StringBuilder());
 
         // Assert
         result.Should().BeTrue();
@@ -47,13 +47,13 @@ public class TypedStringBuilderTemplateRendererTests
     {
         // Arrange
         var sut = new TypedStringBuilderTemplateRenderer();
-        var templateMock = new Mock<IStringBuilderTemplate>();
+        var templateMock = Substitute.For<IStringBuilderTemplate>();
         var builder = new StringBuilder();
 
         // Act
-        _ = sut.TryRender(instance: templateMock.Object, builder);
+        _ = sut.TryRender(instance: templateMock, builder);
 
         // Assert
-        templateMock.Verify(x => x.Render(builder), Times.Once);
+        templateMock.Received().Render(builder);
     }
 }

--- a/src/Core.Tests/StringBuilderTemplateRenderers/TypedTextTransformTemplateRendererTests.cs
+++ b/src/Core.Tests/StringBuilderTemplateRenderers/TypedTextTransformTemplateRendererTests.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests.StringBuilderTemplateRenderers;
+namespace TemplateFramework.Core.Tests.StringBuilderTemplateRenderers;
 
 public class TypedTextTransformTemplateRendererTests
 {
@@ -33,10 +33,10 @@ public class TypedTextTransformTemplateRendererTests
     {
         // Arrange
         var sut = new TypedTextTransformTemplateRenderer();
-        var templateMock = new Mock<ITextTransformTemplate>();
+        var templateMock = Substitute.For<ITextTransformTemplate>();
 
         // Act
-        var result = sut.TryRender(instance: templateMock.Object, new StringBuilder());
+        var result = sut.TryRender(instance: templateMock, new StringBuilder());
 
         // Assert
         result.Should().BeTrue();
@@ -47,13 +47,13 @@ public class TypedTextTransformTemplateRendererTests
     {
         // Arrange
         var sut = new TypedTextTransformTemplateRenderer();
-        var templateMock = new Mock<ITextTransformTemplate>();
+        var templateMock = Substitute.For<ITextTransformTemplate>();
 
         // Act
-        _ = sut.TryRender(instance: templateMock.Object, new StringBuilder());
+        _ = sut.TryRender(instance: templateMock, new StringBuilder());
 
         // Assert
-        templateMock.Verify(x => x.TransformText(), Times.Once);
+        templateMock.Received().TransformText();
     }
 
     [Fact]
@@ -61,12 +61,12 @@ public class TypedTextTransformTemplateRendererTests
     {
         // Arrange
         var sut = new TypedTextTransformTemplateRenderer();
-        var templateMock = new Mock<ITextTransformTemplate>();
-        templateMock.Setup(x => x.TransformText()).Returns("Hello world!");
+        var templateMock = Substitute.For<ITextTransformTemplate>();
+        templateMock.TransformText().Returns("Hello world!");
         var builder = new StringBuilder();
 
         // Act
-        _ = sut.TryRender(instance: templateMock.Object, builder);
+        _ = sut.TryRender(instance: templateMock, builder);
 
         // Assert
         builder.ToString().Should().Be("Hello world!");
@@ -77,11 +77,11 @@ public class TypedTextTransformTemplateRendererTests
     {
         // Arrange
         var sut = new TypedTextTransformTemplateRenderer();
-        var templateMock = new Mock<ITextTransformTemplate>();
-        templateMock.Setup(x => x.TransformText()).Returns("Hello world!");
+        var templateMock = Substitute.For<ITextTransformTemplate>();
+        templateMock.TransformText().Returns("Hello world!");
 
         // Act & Assert
-        sut.Invoking(x => x.TryRender(templateMock.Object, builder: null!))
+        sut.Invoking(x => x.TryRender(templateMock, builder: null!))
            .Should().Throw<ArgumentNullException>().WithParameterName("builder");
     }
 }

--- a/src/Core.Tests/TemplateContext/TemplateContextTests.Constructor.cs
+++ b/src/Core.Tests/TemplateContext/TemplateContextTests.Constructor.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests;
+namespace TemplateFramework.Core.Tests;
 
 public partial class TemplateContextTests
 {
@@ -7,35 +7,35 @@ public partial class TemplateContextTests
         [Fact]
         public void Throws_On_Null_Engine()
         {
-            this.Invoking(_ => new TemplateContext(engine: null!, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), this))
+            this.Invoking(_ => new TemplateContext(engine: null!, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), this))
                 .Should().Throw<ArgumentNullException>().WithParameterName("engine");
         }
 
         [Fact]
         public void Throws_On_Null_TemplateComponentRegistry()
         {
-            this.Invoking(_ => new TemplateContext(EngineMock.Object, templateComponentRegistry: null!, DefaultFilename, new TemplateInstanceIdentifier(this), this))
+            this.Invoking(_ => new TemplateContext(EngineMock, templateComponentRegistry: null!, DefaultFilename, new TemplateInstanceIdentifier(this), this))
                 .Should().Throw<ArgumentNullException>().WithParameterName("templateComponentRegistry");
         }
 
         [Fact]
         public void Throws_On_Null_DefaultFilename()
         {
-            this.Invoking(_ => new TemplateContext(EngineMock.Object, ProviderMock.Object, defaultFilename: null!, new TemplateInstanceIdentifier(this), this))
+            this.Invoking(_ => new TemplateContext(EngineMock, ProviderMock, defaultFilename: null!, new TemplateInstanceIdentifier(this), this))
                 .Should().Throw<ArgumentNullException>().WithParameterName("defaultFilename");
         }
 
         [Fact]
         public void Throws_On_Null_Identifier()
         {
-            this.Invoking(_ => new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, identifier: null!, template: this))
+            this.Invoking(_ => new TemplateContext(EngineMock, ProviderMock, DefaultFilename, identifier: null!, template: this))
                 .Should().Throw<ArgumentNullException>().WithParameterName("identifier");
         }
 
         [Fact]
         public void Throws_On_Null_Template()
         {
-            this.Invoking(_ => new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), template: null!))
+            this.Invoking(_ => new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), template: null!))
                 .Should().Throw<ArgumentNullException>().WithParameterName("template");
         }
 
@@ -43,7 +43,7 @@ public partial class TemplateContextTests
         public void Creates_Instance_On_Non_Null_Template()
         {
             // Act
-            var instance = new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), this);
+            var instance = new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), this);
 
             // Assert
             instance.Template.Should().BeSameAs(this);
@@ -53,7 +53,7 @@ public partial class TemplateContextTests
         public void Creates_Instance_With_Model_When_Supplied()
         {
             // Act
-            var instance = new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: "test");
+            var instance = new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: "test");
 
             // Assert
             instance.Model.Should().BeEquivalentTo("test");
@@ -63,7 +63,7 @@ public partial class TemplateContextTests
         public void Creates_Instance_With_ParentContext_When_Supplied()
         {
             // Act
-            var instance = new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: "current", parentContext: new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: "parent"));
+            var instance = new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: "current", parentContext: new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: "parent"));
 
             // Assert
             instance.Model.Should().BeEquivalentTo("current");
@@ -75,7 +75,7 @@ public partial class TemplateContextTests
         public void Creates_Instance_With_IterationNumber_And_IterationCount_When_Supplied()
         {
             // Act
-            var instance = new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: "test", parentContext: new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: "parent"), iterationNumber: 1, iterationCount: 2);
+            var instance = new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: "test", parentContext: new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: "parent"), iterationNumber: 1, iterationCount: 2);
 
             // Assert
             instance.IterationNumber.Should().Be(1);

--- a/src/Core.Tests/TemplateContext/TemplateContextTests.CreateChildContext.cs
+++ b/src/Core.Tests/TemplateContext/TemplateContextTests.CreateChildContext.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests;
+namespace TemplateFramework.Core.Tests;
 
 public partial class TemplateContextTests
 {
@@ -23,7 +23,7 @@ public partial class TemplateContextTests
             var template = new object();
 
             // Act
-            var childContext = sut.CreateChildContext(new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(template), template: template));
+            var childContext = sut.CreateChildContext(new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(template), template: template));
 
             // Assert
             childContext.Should().NotBeNull();

--- a/src/Core.Tests/TemplateContext/TemplateContextTests.HasIterations.cs
+++ b/src/Core.Tests/TemplateContext/TemplateContextTests.HasIterations.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests;
+namespace TemplateFramework.Core.Tests;
 
 public partial class TemplateContextTests
 {
@@ -12,7 +12,7 @@ public partial class TemplateContextTests
         public void Returns_Correct_Result(int? iterationNumber, int? iterationCount, bool expectedResult)
         {
             // Arrange
-            var sut = new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: string.Empty, parentContext: null, iterationNumber: iterationNumber, iterationCount: iterationCount);
+            var sut = new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: string.Empty, parentContext: null, iterationNumber: iterationNumber, iterationCount: iterationCount);
 
             // Act
             var result = sut.HasIterations;

--- a/src/Core.Tests/TemplateContext/TemplateContextTests.IsFirstIteration.cs
+++ b/src/Core.Tests/TemplateContext/TemplateContextTests.IsFirstIteration.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests;
+namespace TemplateFramework.Core.Tests;
 
 public partial class TemplateContextTests
 {
@@ -13,7 +13,7 @@ public partial class TemplateContextTests
         public void Returns_Correct_Result(int? iterationNumber, int? iterationCount, bool? expectedResult)
         {
             // Arrange
-            var sut = new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: "test", parentContext: new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: "parent"), iterationNumber: iterationNumber, iterationCount: iterationCount);
+            var sut = new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: "test", parentContext: new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: "parent"), iterationNumber: iterationNumber, iterationCount: iterationCount);
 
             // Act
             var result = sut.IsFirstIteration;

--- a/src/Core.Tests/TemplateContext/TemplateContextTests.IsLastIteration.cs
+++ b/src/Core.Tests/TemplateContext/TemplateContextTests.IsLastIteration.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests;
+namespace TemplateFramework.Core.Tests;
 
 public partial class TemplateContextTests
 {
@@ -13,7 +13,7 @@ public partial class TemplateContextTests
         public void Returns_Correct_Result(int? iterationNumber, int? iterationCount, bool? expectedResult)
         {
             // Arrange
-            var sut = new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: "test", parentContext: new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: "parent"), iterationNumber: iterationNumber, iterationCount: iterationCount);
+            var sut = new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: "test", parentContext: new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), this, model: "parent"), iterationNumber: iterationNumber, iterationCount: iterationCount);
 
             // Act
             var result = sut.IsLastIteration;

--- a/src/Core.Tests/TemplateContext/TemplateContextTests.IsRootContext.cs
+++ b/src/Core.Tests/TemplateContext/TemplateContextTests.IsRootContext.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests;
+namespace TemplateFramework.Core.Tests;
 
 public partial class TemplateContextTests
 {
@@ -8,7 +8,7 @@ public partial class TemplateContextTests
         public void Returns_True_When_There_Is_No_ParentContext()
         {
             // Arrange
-            var sut = new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), template: this);
+            var sut = new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), template: this);
 
             // Act
             var result = sut.IsRootContext;
@@ -21,8 +21,8 @@ public partial class TemplateContextTests
         public void Returns_False_When_There_Is_A_ParentContext()
         {
             // Arrange
-            var parentTemplateContext = new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), template: this);
-            var sut = new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), template: this, parentContext: parentTemplateContext);
+            var parentTemplateContext = new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), template: this);
+            var sut = new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), template: this, parentContext: parentTemplateContext);
 
             // Act
             var result = sut.IsRootContext;

--- a/src/Core.Tests/TemplateContext/TemplateContextTests.RootContext.cs
+++ b/src/Core.Tests/TemplateContext/TemplateContextTests.RootContext.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests;
+namespace TemplateFramework.Core.Tests;
 
 public partial class TemplateContextTests
 {
@@ -8,7 +8,7 @@ public partial class TemplateContextTests
         public void Returns_Same_Instance_When_There_Is_No_ParentContext()
         {
             // Arrange
-            var sut = new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), template: this);
+            var sut = new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), template: this);
 
             // Act
             var result = sut.RootContext;
@@ -21,8 +21,8 @@ public partial class TemplateContextTests
         public void Returns_RootContext_One_Level_Deep()
         {
             // Arrange
-            var parentTemplateContext = new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), template: this);
-            var sut = new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), template: this, parentContext: parentTemplateContext);
+            var parentTemplateContext = new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), template: this);
+            var sut = new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), template: this, parentContext: parentTemplateContext);
 
             // Act
             var result = sut.RootContext;
@@ -35,9 +35,9 @@ public partial class TemplateContextTests
         public void Returns_RootContext_Two_Levels_Deep()
         {
             // Arrange
-            var rootTemplateContext = new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), template: this);
-            var parentTemplateContext = new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), template: this, parentContext: rootTemplateContext);
-            var sut = new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(this), template: this, parentContext: parentTemplateContext);
+            var rootTemplateContext = new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), template: this);
+            var parentTemplateContext = new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), template: this, parentContext: rootTemplateContext);
+            var sut = new TemplateContext(EngineMock, ProviderMock, DefaultFilename, new TemplateInstanceIdentifier(this), template: this, parentContext: parentTemplateContext);
 
             // Act
             var result = sut.RootContext;

--- a/src/Core.Tests/TemplateContext/TemplateContextTests.cs
+++ b/src/Core.Tests/TemplateContext/TemplateContextTests.cs
@@ -2,14 +2,14 @@
 
 public partial class TemplateContextTests
 {
-    protected Mock<ITemplateEngine> EngineMock { get; } = new();
-    protected Mock<ITemplateProvider> ProviderMock { get; } = new();
+    protected ITemplateEngine EngineMock { get; } = Substitute.For<ITemplateEngine>();
+    protected ITemplateProvider ProviderMock { get; } = Substitute.For<ITemplateProvider>();
     protected const string DefaultFilename = "Filename.txt";
 
     protected TemplateContext CreateSut()
     {
-        var rootTemplateContext = new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, identifier: new TemplateInstanceIdentifier(this), template: this, model: 1);
-        var parentTemplateContext = new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, identifier: new TemplateInstanceIdentifier(this), template: this, parentContext: rootTemplateContext, model: "test model");
-        return new TemplateContext(EngineMock.Object, ProviderMock.Object, DefaultFilename, identifier: new TemplateInstanceIdentifier(this), template: this, parentContext: parentTemplateContext);
+        var rootTemplateContext = new TemplateContext(EngineMock, ProviderMock, DefaultFilename, identifier: new TemplateInstanceIdentifier(this), template: this, model: 1);
+        var parentTemplateContext = new TemplateContext(EngineMock, ProviderMock, DefaultFilename, identifier: new TemplateInstanceIdentifier(this), template: this, parentContext: rootTemplateContext, model: "test model");
+        return new TemplateContext(EngineMock, ProviderMock, DefaultFilename, identifier: new TemplateInstanceIdentifier(this), template: this, parentContext: parentTemplateContext);
     }
 }

--- a/src/Core.Tests/TemplateEngine/TemplateEngineTests.Constructor.cs
+++ b/src/Core.Tests/TemplateEngine/TemplateEngineTests.Constructor.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests;
+namespace TemplateFramework.Core.Tests;
 
 public partial class TemplateEngineTests
 {
@@ -8,7 +8,7 @@ public partial class TemplateEngineTests
         public void Throws_On_Null_Provider()
         {
             // Act & Assert
-            this.Invoking(_ => new TemplateEngine(provider: null!, TemplateInitializerMock.Object, TemplateParameterExtractorMock.Object, Enumerable.Empty<ITemplateRenderer>()))
+            this.Invoking(_ => new TemplateEngine(provider: null!, TemplateInitializerMock, TemplateParameterExtractorMock, Enumerable.Empty<ITemplateRenderer>()))
                 .Should().Throw<ArgumentNullException>().WithParameterName("provider");
         }
 
@@ -16,7 +16,7 @@ public partial class TemplateEngineTests
         public void Throws_On_Null_Initializer()
         {
             // Act & Assert
-            this.Invoking(_ => new TemplateEngine(TemplateProviderMock.Object, initializer: null!, TemplateParameterExtractorMock.Object, Enumerable.Empty<ITemplateRenderer>()))
+            this.Invoking(_ => new TemplateEngine(TemplateProviderMock, initializer: null!, TemplateParameterExtractorMock, Enumerable.Empty<ITemplateRenderer>()))
                 .Should().Throw<ArgumentNullException>().WithParameterName("initializer");
         }
 
@@ -24,7 +24,7 @@ public partial class TemplateEngineTests
         public void Throws_On_Null_ParameterExtractor()
         {
             // Act & Assert
-            this.Invoking(_ => new TemplateEngine(TemplateProviderMock.Object, TemplateInitializerMock.Object, parameterExtractor: null!, Enumerable.Empty<ITemplateRenderer>()))
+            this.Invoking(_ => new TemplateEngine(TemplateProviderMock, TemplateInitializerMock, parameterExtractor: null!, Enumerable.Empty<ITemplateRenderer>()))
                 .Should().Throw<ArgumentNullException>().WithParameterName("parameterExtractor");
         }
 
@@ -32,7 +32,7 @@ public partial class TemplateEngineTests
         public void Throws_On_Null_Renderers()
         {
             // Act & Assert
-            this.Invoking(_ => new TemplateEngine(TemplateProviderMock.Object, TemplateInitializerMock.Object, TemplateParameterExtractorMock.Object, renderers: null!))
+            this.Invoking(_ => new TemplateEngine(TemplateProviderMock, TemplateInitializerMock, TemplateParameterExtractorMock, renderers: null!))
                 .Should().Throw<ArgumentNullException>().WithParameterName("renderers");
         }
     }

--- a/src/Core.Tests/TemplateEngine/TemplateEngineTests.GetParameters.cs
+++ b/src/Core.Tests/TemplateEngine/TemplateEngineTests.GetParameters.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests;
+namespace TemplateFramework.Core.Tests;
 
 public partial class TemplateEngineTests
 {
@@ -22,7 +22,7 @@ public partial class TemplateEngineTests
             var sut = CreateSut();
             var template = new object();
             var parameters = new[] { new TemplateParameter("name", typeof(string)) };
-            TemplateParameterExtractorMock.Setup(x => x.Extract(template)).Returns(parameters);
+            TemplateParameterExtractorMock.Extract(template).Returns(parameters);
 
             // Act
             var result = sut.GetParameters(template);

--- a/src/Core.Tests/TemplateEngine/TemplateEngineTests.Render.MultipleContentBuilder.cs
+++ b/src/Core.Tests/TemplateEngine/TemplateEngineTests.Render.MultipleContentBuilder.cs
@@ -6,7 +6,7 @@ public partial class TemplateEngineTests
     {
         public Render_MultipleContentBuilder()
         {
-            TemplateRendererMock.Setup(x => x.Supports(It.IsAny<IGenerationEnvironment>())).Returns(true);
+            TemplateRendererMock.Supports(Arg.Any<IGenerationEnvironment>()).Returns(true);
         }
 
         [Fact]
@@ -26,16 +26,16 @@ public partial class TemplateEngineTests
             // Arrange
             var sut = CreateSut();
             var template = new PlainTemplateWithAdditionalParameters();
-            IMultipleContentBuilder? generationEnvironment = MultipleContentBuilderMock.Object;
+            IMultipleContentBuilder? generationEnvironment = MultipleContentBuilderMock;
             var additionalParameters = new { AdditionalParameter = "Some value" };
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), generationEnvironment, additionalParameters);
-            TemplateProviderMock.Setup(x => x.Create(It.IsAny<TemplateInstanceIdentifier>())).Returns(template);
+            TemplateProviderMock.Create(Arg.Any<TemplateInstanceIdentifier>()).Returns(template);
 
             // Act
             sut.Render(request);
 
             // Assert
-            TemplateInitializerMock.Verify(x => x.Initialize(It.IsAny<ITemplateEngineContext>()), Times.Once);
+            TemplateInitializerMock.Received().Initialize(Arg.Any<ITemplateEngineContext>());
         }
 
         [Fact]
@@ -44,20 +44,20 @@ public partial class TemplateEngineTests
             // Arrange
             var sut = CreateSut();
             var template = new PlainTemplateWithAdditionalParameters();
-            IMultipleContentBuilder? generationEnvironment = MultipleContentBuilderMock.Object;
+            IMultipleContentBuilder? generationEnvironment = MultipleContentBuilderMock;
             var additionalParameters = new { AdditionalParameter = "Some value" };
-            TemplateRendererMock.Setup(x => x.Supports(It.IsAny<IGenerationEnvironment>())).Returns(true);
+            TemplateRendererMock.Supports(Arg.Any<IGenerationEnvironment>()).Returns(true);
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), additionalParameters, generationEnvironment);
-            TemplateProviderMock.Setup(x => x.Create(It.IsAny<TemplateInstanceIdentifier>())).Returns(template);
+            TemplateProviderMock.Create(Arg.Any<TemplateInstanceIdentifier>()).Returns(template);
 
             // Act
             sut.Render(request);
 
             // Assert
-            TemplateRendererMock.Verify(x => x.Render(It.Is<ITemplateEngineContext>(req =>
+            TemplateRendererMock.Received().Render(Arg.Is<ITemplateEngineContext>(req =>
                 req.Identifier is TemplateInstanceIdentifier
                 && req.GenerationEnvironment.Type == GenerationEnvironmentType.MultipleContentBuilder
-                && req.DefaultFilename == string.Empty)), Times.Once);
+                && req.DefaultFilename == string.Empty));
         }
     }
 }

--- a/src/Core.Tests/TemplateEngine/TemplateEngineTests.Render.StringBuilder.cs
+++ b/src/Core.Tests/TemplateEngine/TemplateEngineTests.Render.StringBuilder.cs
@@ -6,7 +6,7 @@ public partial class TemplateEngineTests
     {
         public Render_StringBuilder()
         {
-            TemplateRendererMock.Setup(x => x.Supports(It.IsAny<IGenerationEnvironment>())).Returns(true);
+            TemplateRendererMock.Supports(Arg.Any<IGenerationEnvironment>()).Returns(true);
         }
 
         [Fact]
@@ -29,13 +29,13 @@ public partial class TemplateEngineTests
             StringBuilder? builder = StringBuilder;
             var additionalParameters = new { AdditionalParameter = "Some value" };
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), additionalParameters, builder);
-            TemplateProviderMock.Setup(x => x.Create(It.IsAny<TemplateInstanceIdentifier>())).Returns(template);
+            TemplateProviderMock.Create(Arg.Any<TemplateInstanceIdentifier>()).Returns(template);
 
             // Act
             sut.Render(request);
 
             // Assert
-            TemplateInitializerMock.Verify(x => x.Initialize(It.IsAny<ITemplateEngineContext>()), Times.Once);
+            TemplateInitializerMock.Received().Initialize(Arg.Any<ITemplateEngineContext>());
         }
 
         [Fact]
@@ -46,18 +46,18 @@ public partial class TemplateEngineTests
             var template = new PlainTemplateWithAdditionalParameters();
             StringBuilder? generationEnvironment = StringBuilder;
             var additionalParameters = new { AdditionalParameter = "Some value" };
-            TemplateRendererMock.Setup(x => x.Supports(It.IsAny<IGenerationEnvironment>())).Returns(true);
+            TemplateRendererMock.Supports(Arg.Any<IGenerationEnvironment>()).Returns(true);
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), additionalParameters, generationEnvironment);
-            TemplateProviderMock.Setup(x => x.Create(It.IsAny<TemplateInstanceIdentifier>())).Returns(template);
+            TemplateProviderMock.Create(Arg.Any<TemplateInstanceIdentifier>()).Returns(template);
 
             // Act
             sut.Render(request);
 
             // Assert
-            TemplateRendererMock.Verify(x => x.Render(It.Is<ITemplateEngineContext>(req =>
+            TemplateRendererMock.Received().Render(Arg.Is<ITemplateEngineContext>(req =>
                 req.Template == template
                 && req.GenerationEnvironment.Type == GenerationEnvironmentType.StringBuilder
-                && req.DefaultFilename == string.Empty)), Times.Once);
+                && req.DefaultFilename == string.Empty));
         }
     }
 }

--- a/src/Core.Tests/TemplateEngine/TemplateEngineTests.Render.UnsupportedGenerationEnvironmentType.cs
+++ b/src/Core.Tests/TemplateEngine/TemplateEngineTests.Render.UnsupportedGenerationEnvironmentType.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests;
+namespace TemplateFramework.Core.Tests;
 
 public partial class TemplateEngineTests
 {
@@ -8,10 +8,10 @@ public partial class TemplateEngineTests
         public void Throws()
         {
             // Arrange
-            var sut = new TemplateEngine(TemplateProviderMock.Object, TemplateInitializerMock.Object, TemplateParameterExtractorMock.Object, Array.Empty<ITemplateRenderer>()); // we are specifying here that no renderers are known, so even StringBuilder throws an exception :)
+            var sut = new TemplateEngine(TemplateProviderMock, TemplateInitializerMock, TemplateParameterExtractorMock, Array.Empty<ITemplateRenderer>()); // we are specifying here that no renderers are known, so even StringBuilder throws an exception :)
             var template = new TestData.Template(_ => { });
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), new StringBuilder()); // note that we can't put a non-supported type in here because the interface prevents that. But the construction above accomplishes that.
-            TemplateProviderMock.Setup(x => x.Create(It.IsAny<TemplateInstanceIdentifier>())).Returns(template);
+            TemplateProviderMock.Create(Arg.Any<TemplateInstanceIdentifier>()).Returns(template);
 
             // Act & Assert
             sut.Invoking(x => x.Render(request))

--- a/src/Core.Tests/TemplateEngine/TemplateEngineTests.cs
+++ b/src/Core.Tests/TemplateEngine/TemplateEngineTests.cs
@@ -3,12 +3,12 @@
 public partial class TemplateEngineTests
 {
     protected StringBuilder StringBuilder { get; } = new();
-    protected Mock<IMultipleContentBuilder> MultipleContentBuilderMock { get; } = new();
+    protected IMultipleContentBuilder MultipleContentBuilderMock { get; } = Substitute.For<IMultipleContentBuilder>();
 
-    protected Mock<ITemplateProvider> TemplateProviderMock { get; } = new();
-    protected Mock<ITemplateInitializer> TemplateInitializerMock { get; } = new();
-    protected Mock<ITemplateParameterExtractor> TemplateParameterExtractorMock { get; } = new();
-    protected Mock<ITemplateRenderer> TemplateRendererMock { get; } = new();
+    protected ITemplateProvider TemplateProviderMock { get; } = Substitute.For<ITemplateProvider>();
+    protected ITemplateInitializer TemplateInitializerMock { get; } = Substitute.For<ITemplateInitializer>();
+    protected ITemplateParameterExtractor TemplateParameterExtractorMock { get; } = Substitute.For<ITemplateParameterExtractor>();
+    protected ITemplateRenderer TemplateRendererMock { get; } = Substitute.For<ITemplateRenderer>();
 
-    protected TemplateEngine CreateSut() => new(TemplateProviderMock.Object, TemplateInitializerMock.Object, TemplateParameterExtractorMock.Object, new[] { TemplateRendererMock.Object });
+    protected TemplateEngine CreateSut() => new(TemplateProviderMock, TemplateInitializerMock, TemplateParameterExtractorMock, new[] { TemplateRendererMock });
 }

--- a/src/Core.Tests/TemplateEngineContextTests.cs
+++ b/src/Core.Tests/TemplateEngineContextTests.cs
@@ -2,9 +2,9 @@
 
 public class TemplateEngineContextTests
 {
-    protected Mock<IRenderTemplateRequest> RequestMock { get; } = new();
-    protected Mock<ITemplateEngine> EngineMock { get; } = new();
-    protected Mock<ITemplateComponentRegistry> ComponentRegistryMock { get; } = new();
+    protected IRenderTemplateRequest RequestMock { get; } = Substitute.For<IRenderTemplateRequest>();
+    protected ITemplateEngine EngineMock { get; } = Substitute.For<ITemplateEngine>();
+    protected ITemplateComponentRegistry ComponentRegistryMock { get; } = Substitute.For<ITemplateComponentRegistry>();
     protected object Template { get; } = new();
 
     public class Constructor : TemplateEngineContextTests
@@ -13,7 +13,7 @@ public class TemplateEngineContextTests
         public void Should_Throw_On_Null_Request()
         {
             // Act & Assert
-            this.Invoking(_ => new TemplateEngineContext(request: null!, EngineMock.Object, ComponentRegistryMock.Object, Template))
+            this.Invoking(_ => new TemplateEngineContext(request: null!, EngineMock, ComponentRegistryMock, Template))
                 .Should().Throw<ArgumentNullException>().WithParameterName("request");
         }
 
@@ -21,7 +21,7 @@ public class TemplateEngineContextTests
         public void Should_Throw_On_Null_Engine()
         {
             // Act & Assert
-            this.Invoking(_ => new TemplateEngineContext(RequestMock.Object, engine: null!, ComponentRegistryMock.Object, Template))
+            this.Invoking(_ => new TemplateEngineContext(RequestMock, engine: null!, ComponentRegistryMock, Template))
                 .Should().Throw<ArgumentNullException>().WithParameterName("engine");
         }
 
@@ -29,7 +29,7 @@ public class TemplateEngineContextTests
         public void Should_Throw_On_Null_ComponentRegistry()
         {
             // Act & Assert
-            this.Invoking(_ => new TemplateEngineContext(RequestMock.Object, EngineMock.Object, componentRegistry: null!, Template))
+            this.Invoking(_ => new TemplateEngineContext(RequestMock, EngineMock, componentRegistry: null!, Template))
                 .Should().Throw<ArgumentNullException>().WithParameterName("componentRegistry");
         }
 
@@ -37,7 +37,7 @@ public class TemplateEngineContextTests
         public void Should_Throw_On_Null_Template()
         {
             // Act & Assert
-            this.Invoking(_ => new TemplateEngineContext(RequestMock.Object, EngineMock.Object, ComponentRegistryMock.Object, template: null!))
+            this.Invoking(_ => new TemplateEngineContext(RequestMock, EngineMock, ComponentRegistryMock, template: null!))
                 .Should().Throw<ArgumentNullException>().WithParameterName("template");
         }
 
@@ -46,29 +46,29 @@ public class TemplateEngineContextTests
         {
             // Arrange
             var additionalParameters = new object();
-            var templateContextMock = new Mock<ITemplateContext>();
-            var generationEnvironmentMock = new Mock<IGenerationEnvironment>();
-            var identifierMock = new Mock<ITemplateIdentifier>();
+            var templateContextMock = Substitute.For<ITemplateContext>();
+            var generationEnvironmentMock = Substitute.For<IGenerationEnvironment>();
+            var identifierMock = Substitute.For<ITemplateIdentifier>();
             var model = new object();
-            RequestMock.SetupGet(x => x.AdditionalParameters).Returns(additionalParameters);
-            RequestMock.SetupGet(x => x.Context).Returns(templateContextMock.Object);
-            RequestMock.SetupGet(x => x.DefaultFilename).Returns("Filename.txt");
-            RequestMock.SetupGet(x => x.GenerationEnvironment).Returns(generationEnvironmentMock.Object);
-            RequestMock.SetupGet(x => x.Identifier).Returns(identifierMock.Object);
-            RequestMock.SetupGet(x => x.Model).Returns(model);
+            RequestMock.AdditionalParameters.Returns(additionalParameters);
+            RequestMock.Context.Returns(templateContextMock);
+            RequestMock.DefaultFilename.Returns("Filename.txt");
+            RequestMock.GenerationEnvironment.Returns(generationEnvironmentMock);
+            RequestMock.Identifier.Returns(identifierMock);
+            RequestMock.Model.Returns(model);
 
             // Act
-            var instance = new TemplateEngineContext(RequestMock.Object, EngineMock.Object, ComponentRegistryMock.Object, Template);
+            var instance = new TemplateEngineContext(RequestMock, EngineMock, ComponentRegistryMock, Template);
 
             // Assert
-            instance.AdditionalParameters.Should().BeEquivalentTo(RequestMock.Object.AdditionalParameters);
-            instance.ComponentRegistry.Should().BeSameAs(ComponentRegistryMock.Object);
-            instance.Context.Should().BeSameAs(RequestMock.Object.Context);
-            instance.DefaultFilename.Should().BeSameAs(RequestMock.Object.DefaultFilename);
-            instance.Engine.Should().BeSameAs(EngineMock.Object);
-            instance.GenerationEnvironment.Should().BeSameAs(RequestMock.Object.GenerationEnvironment);
-            instance.Identifier.Should().BeSameAs(RequestMock.Object.Identifier);
-            instance.Model.Should().BeSameAs(RequestMock.Object.Model);
+            instance.AdditionalParameters.Should().BeEquivalentTo(RequestMock.AdditionalParameters);
+            instance.ComponentRegistry.Should().BeSameAs(ComponentRegistryMock);
+            instance.Context.Should().BeSameAs(RequestMock.Context);
+            instance.DefaultFilename.Should().BeSameAs(RequestMock.DefaultFilename);
+            instance.Engine.Should().BeSameAs(EngineMock);
+            instance.GenerationEnvironment.Should().BeSameAs(RequestMock.GenerationEnvironment);
+            instance.Identifier.Should().BeSameAs(RequestMock.Identifier);
+            instance.Model.Should().BeSameAs(RequestMock.Model);
             instance.Template.Should().BeSameAs(Template);
         }
     }

--- a/src/Core.Tests/TemplateFramework.Core.Tests.csproj
+++ b/src/Core.Tests/TemplateFramework.Core.Tests.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -48,7 +48,7 @@
     <Using Include="System.Text" />
     <Using Include="FluentAssertions" />
     <Using Include="Microsoft.Extensions.DependencyInjection" />
-    <Using Include="Moq" />
+    <Using Include="NSubstitute" />
     <Using Include="TemplateFramework.Abstractions" />
     <Using Include="TemplateFramework.Abstractions.CodeGeneration" />
     <Using Include="TemplateFramework.Abstractions.Domains" />

--- a/src/Core.Tests/TemplateIdentifiers/TemplateTypeIdentifierTests.cs
+++ b/src/Core.Tests/TemplateIdentifiers/TemplateTypeIdentifierTests.cs
@@ -2,7 +2,7 @@
 
 public class TemplateTypeIdentifierTests
 {
-    protected Mock<ITemplateFactory> TemplateFactoryMock { get; } = new();
+    protected ITemplateFactory TemplateFactoryMock { get; } = Substitute.For<ITemplateFactory>();
 
     public class Constructor : TemplateTypeIdentifierTests
     {
@@ -10,7 +10,7 @@ public class TemplateTypeIdentifierTests
         public void Throws_On_Null_Type()
         {
             // Act & Assert
-            this.Invoking(_ => new TemplateTypeIdentifier(type: null!, TemplateFactoryMock.Object))
+            this.Invoking(_ => new TemplateTypeIdentifier(type: null!, TemplateFactoryMock))
                 .Should().Throw<ArgumentNullException>().WithParameterName("type");
         }
 
@@ -26,7 +26,7 @@ public class TemplateTypeIdentifierTests
         public void Sets_Type_Correctly()
         {
             // Act
-            var identifier = new TemplateTypeIdentifier(GetType(), TemplateFactoryMock.Object);
+            var identifier = new TemplateTypeIdentifier(GetType(), TemplateFactoryMock);
 
             // Assert
             identifier.Type.Should().BeSameAs(GetType());
@@ -36,10 +36,10 @@ public class TemplateTypeIdentifierTests
         public void Sets_TemplateFactory_Correctly()
         {
             // Act
-            var identifier = new TemplateTypeIdentifier(GetType(), TemplateFactoryMock.Object);
+            var identifier = new TemplateTypeIdentifier(GetType(), TemplateFactoryMock);
 
             // Assert
-            identifier.TemplateFactory.Should().BeSameAs(TemplateFactoryMock.Object);
+            identifier.TemplateFactory.Should().BeSameAs(TemplateFactoryMock);
         }
     }
 }

--- a/src/Core.Tests/TemplateInitializer/TemplateInitializerTests.Initialize.cs
+++ b/src/Core.Tests/TemplateInitializer/TemplateInitializerTests.Initialize.cs
@@ -22,12 +22,12 @@ public partial class TemplateInitializerTests
             var sut = CreateSut();
 
             // Act
-            sut.Initialize(new TemplateEngineContext(RenderTemplateRequestMock.Object, TemplateEngineMock.Object, TemplateProviderMock.Object, new object()));
+            sut.Initialize(new TemplateEngineContext(RenderTemplateRequestMock, TemplateEngineMock, TemplateProviderMock, new object()));
 
             // Assert
-            TemplateInitializerComponentMock.Verify(x => x.Initialize(It.Is<ITemplateEngineContext>(x =>
-                x.Engine == TemplateEngineMock.Object
-                && x.Identifier == RenderTemplateRequestMock.Object.Identifier)), Times.Once);
+            TemplateInitializerComponentMock.Received().Initialize(Arg.Is<ITemplateEngineContext>(x =>
+                x.Engine == TemplateEngineMock
+                && x.Identifier == RenderTemplateRequestMock.Identifier));
         }
     }
 }

--- a/src/Core.Tests/TemplateInitializer/TemplateInitializerTests.cs
+++ b/src/Core.Tests/TemplateInitializer/TemplateInitializerTests.cs
@@ -2,10 +2,10 @@
 
 public partial class TemplateInitializerTests
 {
-    protected TemplateInitializer CreateSut() => new(new[] { TemplateInitializerComponentMock.Object });
-    protected Mock<ITemplateEngine> TemplateEngineMock { get; } = new();
-    protected Mock<ITemplateProvider> TemplateProviderMock { get; } = new();
-    protected Mock<ITemplateInitializerComponent> TemplateInitializerComponentMock { get; } = new();
-    protected Mock<IRenderTemplateRequest> RenderTemplateRequestMock { get; } = new();
+    protected TemplateInitializer CreateSut() => new(new[] { TemplateInitializerComponentMock });
+    protected ITemplateEngine TemplateEngineMock { get; } = Substitute.For<ITemplateEngine>();
+    protected ITemplateProvider TemplateProviderMock { get; } = Substitute.For<ITemplateProvider>();
+    protected ITemplateInitializerComponent TemplateInitializerComponentMock { get; } = Substitute.For<ITemplateInitializerComponent>();
+    protected IRenderTemplateRequest RenderTemplateRequestMock { get; } = Substitute.For<IRenderTemplateRequest>();
     protected const string DefaultFilename = "DefaultFilename.txt";
 }

--- a/src/Core.Tests/TemplateInitializerComponents/ContextInitializerTests.cs
+++ b/src/Core.Tests/TemplateInitializerComponents/ContextInitializerTests.cs
@@ -4,9 +4,9 @@ public class ContextInitializerTests
 {
     protected ContextInitializerComponent CreateSut() => new();
     
-    protected Mock<ITemplateEngine> TemplateEngineMock { get; } = new();
-    protected Mock<ITemplateProvider> TemplateProviderMock { get; } = new();
-    
+    protected ITemplateEngine TemplateEngineMock { get; } = Substitute.For<ITemplateEngine>();
+    protected ITemplateProvider TemplateProviderMock { get; } = Substitute.For<ITemplateProvider>();
+
     protected const string DefaultFilename = "DefaultFilename.txt";
 
     public class Initialize : ContextInitializerTests
@@ -28,9 +28,9 @@ public class ContextInitializerTests
             // Arrange
             var sut = CreateSut();
             var template = new TestData.PlainTemplateWithTemplateContext(_ => "Hello world!");
-            var context = new TemplateContext(TemplateEngineMock.Object, TemplateProviderMock.Object, DefaultFilename, new TemplateInstanceIdentifier(template), template);
+            var context = new TemplateContext(TemplateEngineMock, TemplateProviderMock, DefaultFilename, new TemplateInstanceIdentifier(template), template);
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), new StringBuilder(), DefaultFilename, null, context);
-            var engineContext = new TemplateEngineContext(request, TemplateEngineMock.Object, TemplateProviderMock.Object, template);
+            var engineContext = new TemplateEngineContext(request, TemplateEngineMock, TemplateProviderMock, template);
 
             // Act
             sut.Initialize(engineContext);
@@ -46,7 +46,7 @@ public class ContextInitializerTests
             var sut = CreateSut();
             var template = new TestData.PlainTemplateWithTemplateContext(_ => "Hello world!");
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), new StringBuilder(), DefaultFilename, null);
-            var engineContext = new TemplateEngineContext(request, TemplateEngineMock.Object, TemplateProviderMock.Object, template);
+            var engineContext = new TemplateEngineContext(request, TemplateEngineMock, TemplateProviderMock, template);
 
             // Act
             sut.Initialize(engineContext);
@@ -67,7 +67,7 @@ public class ContextInitializerTests
             var template = new TestData.PlainTemplateWithTemplateContext(ctx => ctx.Model?.ToString() ?? string.Empty); // note that this template type does not implement IModelContainer<T>, so the model property will not be set. But it will be available in the TemplateContext (untyped)
             var model = "Hello world!";
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), model, new StringBuilder(), DefaultFilename, null, context: null);
-            var engineContext = new TemplateEngineContext(request, TemplateEngineMock.Object, TemplateProviderMock.Object, template);
+            var engineContext = new TemplateEngineContext(request, TemplateEngineMock, TemplateProviderMock, template);
 
             // Act
             sut.Initialize(engineContext);

--- a/src/Core.Tests/TemplateInitializerComponents/DefaultFilenameInitializerTests.cs
+++ b/src/Core.Tests/TemplateInitializerComponents/DefaultFilenameInitializerTests.cs
@@ -4,9 +4,9 @@ public class DefaultFilenameInitializerTests
 {
     protected DefaultFilenameInitializerComponent CreateSut() => new();
     
-    protected Mock<ITemplateEngine> TemplateEngineMock { get; } = new();
-    protected Mock<ITemplateProvider> TemplateProviderMock { get; } = new();
-    
+    protected ITemplateEngine TemplateEngineMock { get; } = Substitute.For<ITemplateEngine>();
+    protected ITemplateProvider TemplateProviderMock { get; } = Substitute.For<ITemplateProvider>();
+
     protected const string DefaultFilename = "DefaultFilename.txt";
 
     public class Initialize : DefaultFilenameInitializerTests
@@ -29,7 +29,7 @@ public class DefaultFilenameInitializerTests
             var sut = CreateSut();
             var template = new TestData.TemplateWithDefaultFilename(_ => { });
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), null, new StringBuilder(), DefaultFilename);
-            var engineContext = new TemplateEngineContext(request, TemplateEngineMock.Object, TemplateProviderMock.Object, template);
+            var engineContext = new TemplateEngineContext(request, TemplateEngineMock, TemplateProviderMock, template);
 
             // Act
             sut.Initialize(engineContext);

--- a/src/Core.Tests/TemplateInitializerComponents/ModelInitializerTests.cs
+++ b/src/Core.Tests/TemplateInitializerComponents/ModelInitializerTests.cs
@@ -2,12 +2,12 @@
 
 public class ModelInitializerTests
 {
-    protected ModelInitializerComponent CreateSut() => new(ValueConverterMock.Object);
+    protected ModelInitializerComponent CreateSut() => new(ValueConverterMock);
     
-    protected Mock<IValueConverter> ValueConverterMock { get; } = new();
-    protected Mock<ITemplateEngine> TemplateEngineMock { get; } = new();
-    protected Mock<ITemplateProvider> TemplateProviderMock { get; } = new();
-    
+    protected IValueConverter ValueConverterMock { get; } = Substitute.For<IValueConverter>();
+    protected ITemplateEngine TemplateEngineMock { get; } = Substitute.For<ITemplateEngine>();
+    protected ITemplateProvider TemplateProviderMock { get; } = Substitute.For<ITemplateProvider>();
+
     protected const string DefaultFilename = "DefaultFilename.txt";
 
     public class Constructor
@@ -42,8 +42,8 @@ public class ModelInitializerTests
             var model = "Hello world!";
             var template = new TestData.TemplateWithModel<string>(_ => { });
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), model, new StringBuilder(), DefaultFilename);
-            var engineContext = new TemplateEngineContext(request, TemplateEngineMock.Object, TemplateProviderMock.Object, template);
-            ValueConverterMock.Setup(x => x.Convert(It.IsAny<object?>(), It.IsAny<Type>())).Returns<object?, Type>((value, type) => value);
+            var engineContext = new TemplateEngineContext(request, TemplateEngineMock, TemplateProviderMock, template);
+            ValueConverterMock.Convert(Arg.Any<object?>(), Arg.Any<Type>()).Returns(x => x.Args()[0]);
 
             // Act
             sut.Initialize(engineContext);

--- a/src/Core.Tests/TemplateInitializerComponents/ProviderPluginInitializerComponentTests.cs
+++ b/src/Core.Tests/TemplateInitializerComponents/ProviderPluginInitializerComponentTests.cs
@@ -2,12 +2,12 @@
 
 public class ProviderPluginInitializerComponentTests
 {
-    protected ProviderPluginInitializerComponent CreateSut() => new(TemplateProviderPluginFactoryMock.Object);
+    protected ProviderPluginInitializerComponent CreateSut() => new(TemplateProviderPluginFactoryMock);
 
-    protected Mock<ITemplateEngineContext> TemplateEngineContextMock { get; } = new();
-    protected Mock<ITemplateComponentRegistryPlugin> TemplateComponentRegistryPluginMock { get; } = new();
-    protected Mock<ITemplateContext> TemplateContextMock { get; } = new();
-    protected Mock<ITemplateComponentRegistryPluginFactory> TemplateProviderPluginFactoryMock { get; } = new();
+    protected ITemplateEngineContext TemplateEngineContextMock { get; } = Substitute.For<ITemplateEngineContext>();
+    protected ITemplateComponentRegistryPlugin TemplateComponentRegistryPluginMock { get; } = Substitute.For<ITemplateComponentRegistryPlugin>();
+    protected ITemplateContext TemplateContextMock { get; } = Substitute.For<ITemplateContext>();
+    protected ITemplateComponentRegistryPluginFactory TemplateProviderPluginFactoryMock { get; } = Substitute.For<ITemplateComponentRegistryPluginFactory>();
 
     public class Constructor
     {
@@ -38,10 +38,10 @@ public class ProviderPluginInitializerComponentTests
         {
             // Arrange
             var sut = CreateSut();
-            TemplateEngineContextMock.SetupGet(x => x.Template).Returns(TemplateComponentRegistryPluginMock.Object);
+            TemplateEngineContextMock.Template.Returns(TemplateComponentRegistryPluginMock);
 
             // Act & Assert
-            sut.Invoking(x => x.Initialize(TemplateEngineContextMock.Object))
+            sut.Invoking(x => x.Initialize(TemplateEngineContextMock))
                .Should().NotThrow();
         }
 
@@ -50,11 +50,11 @@ public class ProviderPluginInitializerComponentTests
         {
             // Arrange
             var sut = CreateSut();
-            TemplateEngineContextMock.SetupGet(x => x.Context).Returns(TemplateContextMock.Object);
-            TemplateEngineContextMock.SetupGet(x => x.Template).Returns(new object());
+            TemplateEngineContextMock.Context.Returns(TemplateContextMock);
+            TemplateEngineContextMock.Template.Returns(new object());
 
             // Act & Assert
-            sut.Invoking(x => x.Initialize(TemplateEngineContextMock.Object))
+            sut.Invoking(x => x.Initialize(TemplateEngineContextMock))
                .Should().NotThrow();
         }
 
@@ -63,14 +63,14 @@ public class ProviderPluginInitializerComponentTests
         {
             // Arrange
             var sut = CreateSut();
-            TemplateEngineContextMock.SetupGet(x => x.Context).Returns(TemplateContextMock.Object);
-            TemplateEngineContextMock.SetupGet(x => x.Template).Returns(TemplateComponentRegistryPluginMock.Object);
+            TemplateEngineContextMock.Context.Returns(TemplateContextMock);
+            TemplateEngineContextMock.Template.Returns(TemplateComponentRegistryPluginMock);
 
             // Act
-            sut.Initialize(TemplateEngineContextMock.Object);
+            sut.Initialize(TemplateEngineContextMock);
 
             // Assert
-            TemplateComponentRegistryPluginMock.Verify(x => x.Initialize(It.IsAny<ITemplateProvider>()), Times.Once);
+            TemplateComponentRegistryPluginMock.Received().Initialize(Arg.Any<ITemplateComponentRegistry>());
         }
 
         [Fact]
@@ -79,16 +79,16 @@ public class ProviderPluginInitializerComponentTests
             // Arrange
             var identifier = new IdentifierWithTemplateProviderPluginIdentifier(GetType().Assembly.FullName, GetType().FullName!, Directory.GetCurrentDirectory());
             var sut = CreateSut();
-            TemplateEngineContextMock.SetupGet(x => x.Context).Returns(TemplateContextMock.Object);
-            TemplateEngineContextMock.SetupGet(x => x.Template).Returns(new object());
-            TemplateEngineContextMock.SetupGet(x => x.Identifier).Returns(identifier);
-            TemplateProviderPluginFactoryMock.Setup(x => x.Create(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(TemplateComponentRegistryPluginMock.Object);
+            TemplateEngineContextMock.Context.Returns(TemplateContextMock);
+            TemplateEngineContextMock.Template.Returns(new object());
+            TemplateEngineContextMock.Identifier.Returns(identifier);
+            TemplateProviderPluginFactoryMock.Create(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()).Returns(TemplateComponentRegistryPluginMock);
 
             // Act
-            sut.Initialize(TemplateEngineContextMock.Object);
+            sut.Initialize(TemplateEngineContextMock);
 
             // Assert
-            TemplateComponentRegistryPluginMock.Verify(x => x.Initialize(It.IsAny<ITemplateProvider>()), Times.Once);
+            TemplateComponentRegistryPluginMock.Received().Initialize(Arg.Any<ITemplateComponentRegistry>());
         }
 
         private sealed class IdentifierWithTemplateProviderPluginIdentifier : ITemplateComponentRegistryIdentifier

--- a/src/Core.Tests/TemplateParameterExtractorComponents/TypedExtractorTests.cs
+++ b/src/Core.Tests/TemplateParameterExtractorComponents/TypedExtractorTests.cs
@@ -4,7 +4,7 @@ public class TypedExtractorTests
 {
     protected TypedExtractor CreateSut() => new();
 
-    protected Mock<IParameterizedTemplate> ParameterizedTemplateMock { get; } = new();
+    protected IParameterizedTemplate ParameterizedTemplateMock { get; } = Substitute.For<IParameterizedTemplate>();
 
     public class Extract : TypedExtractorTests
     {
@@ -36,10 +36,10 @@ public class TypedExtractorTests
             // Arrange
             var sut = CreateSut();
             var parameters = new[] { new TemplateParameter("SomeName", typeof(string)) };
-            ParameterizedTemplateMock.Setup(x => x.GetParameters()).Returns(parameters);
+            ParameterizedTemplateMock.GetParameters().Returns(parameters);
 
             // Act
-            var result = sut.Extract(ParameterizedTemplateMock.Object);
+            var result = sut.Extract(ParameterizedTemplateMock);
 
             // Assert
             result.Should().BeEquivalentTo(parameters);
@@ -55,7 +55,7 @@ public class TypedExtractorTests
             var sut = CreateSut();
 
             // Act
-            var result = sut.Supports(ParameterizedTemplateMock.Object);
+            var result = sut.Supports(ParameterizedTemplateMock);
 
             // Assert
             result.Should().BeTrue();

--- a/src/Core.Tests/TemplateParameterExtractorTests.cs
+++ b/src/Core.Tests/TemplateParameterExtractorTests.cs
@@ -2,9 +2,9 @@
 
 public class TemplateParameterExtractorTests
 {
-    protected TemplateParameterExtractor CreateSut() => new(new[] { TemplateParameterExtractorComponentMock.Object });
+    protected TemplateParameterExtractor CreateSut() => new(new[] { TemplateParameterExtractorComponentMock });
 
-    protected Mock<ITemplateParameterExtractorComponent> TemplateParameterExtractorComponentMock { get; } = new();
+    protected ITemplateParameterExtractorComponent TemplateParameterExtractorComponentMock { get; } = Substitute.For<ITemplateParameterExtractorComponent>();
 
     public class Constructor
     {
@@ -49,8 +49,8 @@ public class TemplateParameterExtractorTests
             var sut = CreateSut();
             var template = new object();
             var parameters = new[] { new TemplateParameter("name", typeof(string)) };
-            TemplateParameterExtractorComponentMock.Setup(x => x.Supports(template)).Returns(true);
-            TemplateParameterExtractorComponentMock.Setup(x => x.Extract(template)).Returns(parameters);
+            TemplateParameterExtractorComponentMock.Supports(template).Returns(true);
+            TemplateParameterExtractorComponentMock.Extract(template).Returns(parameters);
 
             // Act
             var result = sut.Extract(template);

--- a/src/Core.Tests/TemplateProviderTests.cs
+++ b/src/Core.Tests/TemplateProviderTests.cs
@@ -2,9 +2,9 @@
 
 public class TemplateProviderTests
 {
-    protected TemplateProvider CreateSut() => new(new[] { TemplateProviderComponentMock.Object });
+    protected TemplateProvider CreateSut() => new(new[] { TemplateProviderComponentMock });
 
-    protected Mock<ITemplateProviderComponent> TemplateProviderComponentMock { get; } = new();
+    protected ITemplateProviderComponent TemplateProviderComponentMock { get; } = Substitute.For<ITemplateProviderComponent>();
 
     public class Constructor
     {
@@ -37,7 +37,7 @@ public class TemplateProviderTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.Create(identifier: new Mock<ITemplateIdentifier>().Object))
+            sut.Invoking(x => x.Create(identifier: Substitute.For<ITemplateIdentifier>()))
                .Should().Throw<NotSupportedException>();
         }
 
@@ -46,10 +46,10 @@ public class TemplateProviderTests
         {
             // Arrange
             var sut = CreateSut();
-            var identifier = new Mock<ITemplateIdentifier>().Object;
+            var identifier = Substitute.For<ITemplateIdentifier>();
             var expectedTemplate = new object();
-            TemplateProviderComponentMock.Setup(x => x.Supports(identifier)).Returns(true);
-            TemplateProviderComponentMock.Setup(x => x.Create(identifier)).Returns(expectedTemplate);
+            TemplateProviderComponentMock.Supports(identifier).Returns(true);
+            TemplateProviderComponentMock.Create(identifier).Returns(expectedTemplate);
 
             // Act
             var template = sut.Create(identifier);
@@ -77,18 +77,18 @@ public class TemplateProviderTests
         {
             // Arrange
             var sut = CreateSut();
-            var customTemplateProviderComponentMock = new Mock<ITemplateProviderComponent>();
-            var identifier = new Mock<ITemplateIdentifier>().Object;
+            var customTemplateProviderComponentMock = Substitute.For<ITemplateProviderComponent>();
+            var identifier = Substitute.For<ITemplateIdentifier>();
             var expectedTemplate = new object();
-            customTemplateProviderComponentMock.Setup(x => x.Supports(identifier)).Returns(true);
-            customTemplateProviderComponentMock.Setup(x => x.Create(identifier)).Returns(expectedTemplate);
+            customTemplateProviderComponentMock.Supports(identifier).Returns(true);
+            customTemplateProviderComponentMock.Create(identifier).Returns(expectedTemplate);
 
             // Act
-            sut.RegisterComponent(customTemplateProviderComponentMock.Object);
+            sut.RegisterComponent(customTemplateProviderComponentMock);
 
             // Assert
             sut.Create(identifier);
-            customTemplateProviderComponentMock.Verify(x => x.Create(identifier), Times.Once);
+            customTemplateProviderComponentMock.Received().Create(identifier);
         }
     }
 
@@ -99,17 +99,17 @@ public class TemplateProviderTests
         {
             // Arrange
             var sut = CreateSut();
-            var newTemplateProviderComponentMock = new Mock<ITemplateProviderComponent>();
-            newTemplateProviderComponentMock.Setup(x => x.Supports(It.IsAny<ITemplateIdentifier>())).Returns(true);
-            newTemplateProviderComponentMock.Setup(x => x.Create(It.IsAny<ITemplateIdentifier>())).Returns(this);
-            var templateIdentifierMock = new Mock<ITemplateIdentifier>();
-            sut.RegisterComponent(newTemplateProviderComponentMock.Object);
+            var newTemplateProviderComponentMock = Substitute.For<ITemplateProviderComponent>();
+            newTemplateProviderComponentMock.Supports(Arg.Any<ITemplateIdentifier>()).Returns(true);
+            newTemplateProviderComponentMock.Create(Arg.Any<ITemplateIdentifier>()).Returns(this);
+            var templateIdentifierMock = Substitute.For<ITemplateIdentifier>();
+            sut.RegisterComponent(newTemplateProviderComponentMock);
 
             // Act
             sut.StartSession();
 
             // Assert
-            sut.Invoking(x => x.Create(templateIdentifierMock.Object))
+            sut.Invoking(x => x.Create(templateIdentifierMock))
                .Should().Throw<NotSupportedException>();
         }
 

--- a/src/Core.Tests/TemplateRenderers/MultipleContentTemplateRendererTests.Supports.cs
+++ b/src/Core.Tests/TemplateRenderers/MultipleContentTemplateRendererTests.Supports.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests.TemplateRenderers;
+namespace TemplateFramework.Core.Tests.TemplateRenderers;
 
 public partial class MultipleContentTemplateRendererTests
 {
@@ -9,11 +9,11 @@ public partial class MultipleContentTemplateRendererTests
         {
             // Arrange
             var sut = CreateSut();
-            var environmentMock = new Mock<IGenerationEnvironment>();
-            environmentMock.SetupGet(x => x.Type).Returns(GenerationEnvironmentType.StringBuilder);
+            var environmentMock = Substitute.For<IGenerationEnvironment>();
+            environmentMock.Type.Returns(GenerationEnvironmentType.StringBuilder);
 
             // Act
-            var result = sut.Supports(environmentMock.Object);
+            var result = sut.Supports(environmentMock);
 
             // Assert
             result.Should().BeFalse();
@@ -37,7 +37,7 @@ public partial class MultipleContentTemplateRendererTests
         {
             // Arrange
             var sut = CreateSut();
-            var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(this), DefaultFilename, new Mock<IMultipleContentBuilder>().Object);
+            var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(this), DefaultFilename, Substitute.For<IMultipleContentBuilder>());
 
             // Act
             var result = sut.Supports(request.GenerationEnvironment);

--- a/src/Core.Tests/TemplateRenderers/MultipleContentTemplateRendererTests.cs
+++ b/src/Core.Tests/TemplateRenderers/MultipleContentTemplateRendererTests.cs
@@ -2,11 +2,11 @@
 
 public partial class MultipleContentTemplateRendererTests
 {
-    protected Mock<ITemplateProvider> TemplateProviderMock { get; } = new();
-    protected Mock<IMultipleContentBuilderTemplateCreator> MultipleContentBuilderTemplateCreatorMock { get; } = new();
-    protected Mock<ITemplateEngine> TemplateEngineMock { get; } = new();
+    protected ITemplateProvider TemplateProviderMock { get; } = Substitute.For<ITemplateProvider>();
+    protected IMultipleContentBuilderTemplateCreator MultipleContentBuilderTemplateCreatorMock { get; } = Substitute.For<IMultipleContentBuilderTemplateCreator>();
+    protected ITemplateEngine TemplateEngineMock { get; } = Substitute.For<ITemplateEngine>();
 
-    protected MultipleContentTemplateRenderer CreateSut() => new(new[] { MultipleContentBuilderTemplateCreatorMock.Object });
+    protected MultipleContentTemplateRenderer CreateSut() => new(new[] { MultipleContentBuilderTemplateCreatorMock });
 
     protected const string DefaultFilename = "MyFile.txt";
 }

--- a/src/Core.Tests/TemplateRenderers/StringBuilderTemplateRendererTests.Render.cs
+++ b/src/Core.Tests/TemplateRenderers/StringBuilderTemplateRendererTests.Render.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests.TemplateRenderers;
+namespace TemplateFramework.Core.Tests.TemplateRenderers;
 
 public partial class StringBuilderTemplateRendererTests
 {
@@ -6,8 +6,7 @@ public partial class StringBuilderTemplateRendererTests
     {
         public Render()
         {
-            StringBuilderTemplateRendererMock
-                .Setup(x => x.TryRender(It.IsAny<object>(), It.IsAny<StringBuilder>()))
+            StringBuilderTemplateRendererMock.TryRender(Arg.Any<object>(), Arg.Any<StringBuilder>())
                 .Returns(true);
         }
 
@@ -28,8 +27,8 @@ public partial class StringBuilderTemplateRendererTests
             // Arrange
             var sut = CreateSut();
             var template = new TestData.Template(_ => { });
-            var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), new Mock<IMultipleContentBuilder>().Object);
-            var engineContext = new TemplateEngineContext(request, TemplateEngineMock.Object, TemplateProviderMock.Object, template);
+            var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), Substitute.For<IMultipleContentBuilder>());
+            var engineContext = new TemplateEngineContext(request, TemplateEngineMock, TemplateProviderMock, template);
 
             // Act & Assert
             sut.Invoking(x => x.Render(engineContext))
@@ -44,13 +43,13 @@ public partial class StringBuilderTemplateRendererTests
             var template = new TestData.Template(b => b.Append("Hello world!"));
             var generationEnvironment = new StringBuilder();
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), generationEnvironment);
-            var engineContext = new TemplateEngineContext(request, TemplateEngineMock.Object, TemplateProviderMock.Object, template);
+            var engineContext = new TemplateEngineContext(request, TemplateEngineMock, TemplateProviderMock, template);
 
             // Act
             sut.Render(engineContext);
 
             // Assert
-            StringBuilderTemplateRendererMock.Verify(x => x.TryRender(It.IsAny<object>(), It.IsAny<StringBuilder>()), Times.Once);
+            StringBuilderTemplateRendererMock.Received().TryRender(Arg.Any<object>(), Arg.Any<StringBuilder>());
         }
 
         [Fact]
@@ -61,9 +60,8 @@ public partial class StringBuilderTemplateRendererTests
             var template = new TestData.Template(b => b.Append("Hello world!"));
             var generationEnvironment = new StringBuilder();
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), generationEnvironment);
-            var engineContext = new TemplateEngineContext(request, TemplateEngineMock.Object, TemplateProviderMock.Object, template);
-            StringBuilderTemplateRendererMock
-                .Setup(x => x.TryRender(It.IsAny<object>(), It.IsAny<StringBuilder>()))
+            var engineContext = new TemplateEngineContext(request, TemplateEngineMock, TemplateProviderMock, template);
+            StringBuilderTemplateRendererMock.TryRender(Arg.Any<object>(), Arg.Any<StringBuilder>())
                 .Returns(false);
 
             // Act

--- a/src/Core.Tests/TemplateRenderers/StringBuilderTemplateRendererTests.Supports.cs
+++ b/src/Core.Tests/TemplateRenderers/StringBuilderTemplateRendererTests.Supports.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Core.Tests.TemplateRenderers;
+namespace TemplateFramework.Core.Tests.TemplateRenderers;
 
 public partial class StringBuilderTemplateRendererTests
 {
@@ -23,7 +23,7 @@ public partial class StringBuilderTemplateRendererTests
         {
             // Arrange
             var sut = CreateSut();
-            var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(this), new Mock<IMultipleContentBuilder>().Object);
+            var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(this), Substitute.For<IMultipleContentBuilder>());
 
             // Act
             var result = sut.Supports(request.GenerationEnvironment);

--- a/src/Core.Tests/TemplateRenderers/StringBuilderTemplateRendererTests.cs
+++ b/src/Core.Tests/TemplateRenderers/StringBuilderTemplateRendererTests.cs
@@ -2,9 +2,9 @@
 
 public partial class StringBuilderTemplateRendererTests
 {
-    protected Mock<IStringBuilderTemplateRenderer> StringBuilderTemplateRendererMock { get; } = new();
-    protected Mock<ITemplateEngine> TemplateEngineMock { get; } = new();
-    protected Mock<ITemplateProvider> TemplateProviderMock { get; } = new();
+    protected IStringBuilderTemplateRenderer StringBuilderTemplateRendererMock { get; } = Substitute.For<IStringBuilderTemplateRenderer>();
+    protected ITemplateEngine TemplateEngineMock { get; } = Substitute.For<ITemplateEngine>();
+    protected ITemplateProvider TemplateProviderMock { get; } = Substitute.For<ITemplateProvider>();
 
-    protected StringBuilderTemplateRenderer CreateSut() => new(new[] { StringBuilderTemplateRendererMock.Object });
+    protected StringBuilderTemplateRenderer CreateSut() => new(new[] { StringBuilderTemplateRendererMock });
 }

--- a/src/Core.Tests/ValueConverterTests.cs
+++ b/src/Core.Tests/ValueConverterTests.cs
@@ -2,9 +2,9 @@
 
 public class ValueConverterTests
 {
-    protected ValueConverter CreateSut() => new(new[] { TemplateParameterConverterMock.Object });
+    protected ValueConverter CreateSut() => new(new[] { TemplateParameterConverterMock });
 
-    protected Mock<ITemplateParameterConverter> TemplateParameterConverterMock { get; } = new();
+    protected ITemplateParameterConverter TemplateParameterConverterMock { get; } = Substitute.For<ITemplateParameterConverter>();
 
     public class Constructor
     {
@@ -39,15 +39,18 @@ public class ValueConverterTests
             // Arrange
             var sut = CreateSut();
             var value = "Hello world!";
-            object? convertedValue = value.ToUpperInvariant();
-            TemplateParameterConverterMock.Setup(x => x.TryConvert(It.IsAny<object?>(), It.IsAny<Type>(), out convertedValue)).Returns(true);
+            TemplateParameterConverterMock.TryConvert(Arg.Any<object?>(), Arg.Any<Type>(), out Arg.Any<object?>()).Returns(x =>
+            {
+                x[2] = value.ToUpperInvariant();
+                return true;
+            });
 
             // Act
             var result = sut.Convert(value, value.GetType());
 
             // Assert
             result.Should().BeEquivalentTo(value.ToUpperInvariant());
-            TemplateParameterConverterMock.Verify(x => x.TryConvert(It.IsAny<object?>(), It.IsAny<Type>(), out convertedValue), Times.Once);
+            TemplateParameterConverterMock.Received().TryConvert(Arg.Any<object?>(), Arg.Any<Type>(), out Arg.Any<object?>());
         }
     }
 }

--- a/src/Core/TemplateFramework.Core.csproj
+++ b/src/Core/TemplateFramework.Core.csproj
@@ -10,6 +10,9 @@
     <PackageTags>templateengine;codegeneration</PackageTags>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/pauldeen79/TemplateFramework</RepositoryUrl>
+    <!-- Used by code coverage -->
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Runtime.Tests/Extensions/ServiceCollectionExtensions/ServiceCollectionExtensionsTests.AddTemplateFrameworkCodeGeneration.cs
+++ b/src/Runtime.Tests/Extensions/ServiceCollectionExtensions/ServiceCollectionExtensionsTests.AddTemplateFrameworkCodeGeneration.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.Runtime.Tests.Extensions;
+namespace TemplateFramework.Runtime.Tests.Extensions;
 
 public class ServiceCollectionExtensionsTests
 {
@@ -10,7 +10,7 @@ public class ServiceCollectionExtensionsTests
             // Act
             using var provider = new ServiceCollection()
                 .AddTemplateFrameworkRuntime()
-                .AddSingleton(new Mock<IAssemblyInfoContextService>().Object)
+                .AddSingleton(Substitute.For<IAssemblyInfoContextService>())
                 .BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
 
             // Assert

--- a/src/Runtime.Tests/TemplateFramework.Runtime.Tests.csproj
+++ b/src/Runtime.Tests/TemplateFramework.Runtime.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -14,7 +14,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -33,7 +33,7 @@
   <ItemGroup>
     <Using Include="FluentAssertions" />
     <Using Include="Microsoft.Extensions.DependencyInjection" />
-    <Using Include="Moq" />
+    <Using Include="NSubstitute" />
     <Using Include="TemplateFramework.Runtime.Abstractions" />
     <Using Include="TemplateFramework.Runtime.Extensions" />
     <Using Include="Xunit" />

--- a/src/Runtime/TemplateFramework.Runtime.csproj
+++ b/src/Runtime/TemplateFramework.Runtime.csproj
@@ -10,6 +10,9 @@
     <PackageTags>templateengine;codegeneration</PackageTags>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/pauldeen79/TemplateFramework</RepositoryUrl>
+    <!-- Used by code coverage -->
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TemplateProviders.ChildTemplateProvider.Tests/Extensions/ServiceCollectionExtensions/ServiceCollectionExtensionsTests.AddTemplateFrameworkChildTemplateProvider.cs
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/Extensions/ServiceCollectionExtensions/ServiceCollectionExtensionsTests.AddTemplateFrameworkChildTemplateProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.TemplateProviders.ChildTemplateProvider.Tests.Extensions;
+namespace TemplateFramework.TemplateProviders.ChildTemplateProvider.Tests.Extensions;
 
 public class ServiceCollectionExtensionsTests
 {
@@ -11,7 +11,7 @@ public class ServiceCollectionExtensionsTests
             using var provider = new ServiceCollection()
                 .AddTemplateFramework()
                 .AddTemplateFrameworkChildTemplateProvider()
-                .AddSingleton(new Mock<ITemplateComponentRegistryPluginFactory>().Object)
+                .AddSingleton(Substitute.For<ITemplateComponentRegistryPluginFactory>())
                 .BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
 
             // Assert

--- a/src/TemplateProviders.ChildTemplateProvider.Tests/IntegrationTests.cs
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/IntegrationTests.cs
@@ -10,7 +10,7 @@ public class IntegrationTests
             .AddTemplateFramework()
             .AddTemplateFrameworkChildTemplateProvider()
             .AddChildTemplate("MyTemplate", _ => new TestData.PlainTemplateWithTemplateContext(context => "Context IsRootContext: " + context.IsRootContext))
-            .AddSingleton(new Mock<ITemplateComponentRegistryPluginFactory>().Object)
+            .AddSingleton(Substitute.For<ITemplateComponentRegistryPluginFactory>())
             .BuildServiceProvider(true);
         using var scope = provider.CreateScope();
         var engine = scope.ServiceProvider.GetRequiredService<ITemplateEngine>();
@@ -34,14 +34,14 @@ public class IntegrationTests
     public void Can_Render_Multiple_Files_Into_One_File_Like_Current_CsharpClassGenerator()
     {
         // Arrange
-        var templateFactoryMock = new Mock<ITemplateFactory>();
-        templateFactoryMock.Setup(x => x.Create(It.IsAny<Type>())).Returns<Type>(t => Activator.CreateInstance(t)!);
+        var templateFactoryMock = Substitute.For<ITemplateFactory>();
+        templateFactoryMock.Create(Arg.Any<Type>()).Returns(x => Activator.CreateInstance(x.ArgAt<Type>(0))!);
         using var provider = new ServiceCollection()
             .AddTemplateFramework()
             .AddTemplateFrameworkChildTemplateProvider()
             .AddTemplateFrameworkCodeGeneration()
-            .AddSingleton(templateFactoryMock.Object) // note that normally, this class needs to be implemented by the host. (like TemplateFramework.Console)
-            .AddSingleton(new Mock<ITemplateComponentRegistryPluginFactory>().Object) // note that normally, this class needs to be implemented by the host. (like TemplateFramework.Console)
+            .AddSingleton(templateFactoryMock) // note that normally, this class needs to be implemented by the host. (like TemplateFramework.Console)
+            .AddSingleton(Substitute.For<ITemplateComponentRegistryPluginFactory>()) // note that normally, this class needs to be implemented by the host. (like TemplateFramework.Console)
             .BuildServiceProvider(true);
         using var scope = provider.CreateScope();
 

--- a/src/TemplateProviders.ChildTemplateProvider.Tests/ProviderComponent/ProviderComponentTests.Create.cs
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/ProviderComponent/ProviderComponentTests.Create.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.TemplateProviders.ChildTemplateProvider.Tests;
+namespace TemplateFramework.TemplateProviders.ChildTemplateProvider.Tests;
     
 public partial class ProviderComponentTests
 {
@@ -22,7 +22,7 @@ public partial class ProviderComponentTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.Create(new Mock<ITemplateIdentifier>().Object))
+            sut.Invoking(x => x.Create(Substitute.For<ITemplateIdentifier>()))
                .Should().Throw<NotSupportedException>();
         }
     }

--- a/src/TemplateProviders.ChildTemplateProvider.Tests/ProviderComponent/ProviderComponentTests.CreateByModel.cs
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/ProviderComponent/ProviderComponentTests.CreateByModel.cs
@@ -9,8 +9,8 @@ public partial class ProviderComponentTests
         {
             // Arrange
             var sut = CreateSut();
-            TemplateCreatorMock.Setup(x => x.SupportsModel(It.IsAny<object?>())).Returns(true);
-            TemplateCreatorMock.Setup(x => x.CreateByModel(It.IsAny<object?>())).Returns(new object());
+            TemplateCreatorMock.SupportsModel(Arg.Any<object?>()).Returns(true);
+            TemplateCreatorMock.CreateByModel(Arg.Any<object?>()).Returns(new object());
 
             // Act & Assert
             sut.Invoking(x => x.Create(new TemplateByModelIdentifier(null)))
@@ -22,7 +22,7 @@ public partial class ProviderComponentTests
         {
             // Arrange
             var sut = CreateSut();
-            TemplateCreatorMock.Setup(x => x.SupportsModel(It.IsAny<object?>())).Returns(false);
+            TemplateCreatorMock.SupportsModel(Arg.Any<object?>()).Returns(false);
 
             // Act & Assert
             sut.Invoking(x => x.Create(new TemplateByModelIdentifier(1)))
@@ -34,7 +34,7 @@ public partial class ProviderComponentTests
         {
             // Arrange
             var sut = CreateSut();
-            TemplateCreatorMock.Setup(x => x.SupportsModel(It.IsAny<object?>())).Returns(false);
+            TemplateCreatorMock.SupportsModel(Arg.Any<object?>()).Returns(false);
 
             // Act & Assert
             sut.Invoking(x => x.Create(new TemplateByModelIdentifier(null)))
@@ -46,8 +46,8 @@ public partial class ProviderComponentTests
         {
             // Arrange
             var sut = CreateSut();
-            TemplateCreatorMock.Setup(x => x.SupportsModel(It.IsAny<object?>())).Returns(true);
-            TemplateCreatorMock.Setup(x => x.CreateByModel(It.IsAny<object?>())).Returns(null!);
+            TemplateCreatorMock.SupportsModel(Arg.Any<object?>()).Returns(true);
+            TemplateCreatorMock.CreateByModel(Arg.Any<object?>()).Returns(null!);
 
             // Act & Assert
             sut.Invoking(x => x.Create(new TemplateByModelIdentifier(null!)))
@@ -60,8 +60,8 @@ public partial class ProviderComponentTests
             // Arrange
             var sut = CreateSut();
             var template = new object();
-            TemplateCreatorMock.Setup(x => x.SupportsModel(It.IsAny<object?>())).Returns<object>(x => x is int);
-            TemplateCreatorMock.Setup(x => x.CreateByModel(It.IsAny<object?>())).Returns(template);
+            TemplateCreatorMock.SupportsModel(Arg.Any<object?>()).Returns<object>(x => x.Args()[0] is int);
+            TemplateCreatorMock.CreateByModel(Arg.Any<object?>()).Returns(template);
 
             // Act
             var result = sut.Create(new TemplateByModelIdentifier(1));

--- a/src/TemplateProviders.ChildTemplateProvider.Tests/ProviderComponent/ProviderComponentTests.CreateByName.cs
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/ProviderComponent/ProviderComponentTests.CreateByName.cs
@@ -20,7 +20,7 @@ public partial class ProviderComponentTests
         {
             // Arrange
             var sut = CreateSut();
-            TemplateCreatorMock.Setup(x => x.SupportsName(It.IsAny<string>())).Returns(false);
+            TemplateCreatorMock.SupportsName(Arg.Any<string>()).Returns(false);
 
             // Act & Assert
             sut.Invoking(x => x.Create(new TemplateByNameIdentifier("test")))
@@ -32,8 +32,8 @@ public partial class ProviderComponentTests
         {
             // Arrange
             var sut = CreateSut();
-            TemplateCreatorMock.Setup(x => x.SupportsName(It.IsAny<string>())).Returns(true);
-            TemplateCreatorMock.Setup(x => x.CreateByName(It.IsAny<string>())).Returns(null!);
+            TemplateCreatorMock.SupportsName(Arg.Any<string>()).Returns(true);
+            TemplateCreatorMock.CreateByName(Arg.Any<string>()).Returns(null!);
 
             // Act & Assert
             sut.Invoking(x => x.Create(new TemplateByNameIdentifier("test")))
@@ -46,8 +46,8 @@ public partial class ProviderComponentTests
             // Arrange
             var sut = CreateSut();
             var template = new object();
-            TemplateCreatorMock.Setup(x => x.SupportsName(It.IsAny<string>())).Returns<string>(x => x == "test");
-            TemplateCreatorMock.Setup(x => x.CreateByName(It.IsAny<string>())).Returns(template);
+            TemplateCreatorMock.SupportsName(Arg.Any<string>()).Returns(x => x.ArgAt<string>(0) == "test");
+            TemplateCreatorMock.CreateByName(Arg.Any<string>()).Returns(template);
 
             // Act
             var result = sut.Create(new TemplateByNameIdentifier("test"));

--- a/src/TemplateProviders.ChildTemplateProvider.Tests/ProviderComponent/ProviderComponentTests.Supports.cs
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/ProviderComponent/ProviderComponentTests.Supports.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.TemplateProviders.ChildTemplateProvider.Tests;
+namespace TemplateFramework.TemplateProviders.ChildTemplateProvider.Tests;
 
 public partial class ProviderComponentTests
 {
@@ -23,7 +23,7 @@ public partial class ProviderComponentTests
         {
             // Arrange
             var sut = CreateSut();
-            var identifier = new Mock<ITemplateIdentifier>().Object;
+            var identifier = Substitute.For<ITemplateIdentifier>();
 
             // Act
             var result = sut.Supports(identifier);
@@ -38,7 +38,7 @@ public partial class ProviderComponentTests
             // Arrange
             var sut = CreateSut();
             var identifier = new TemplateByModelIdentifier(this);
-            TemplateCreatorMock.Setup(x => x.SupportsModel(It.IsAny<object?>())).Returns(true);
+            TemplateCreatorMock.SupportsModel(Arg.Any<object?>()).Returns(true);
 
             // Act
             var result = sut.Supports(identifier);
@@ -53,7 +53,7 @@ public partial class ProviderComponentTests
             // Arrange
             var sut = CreateSut();
             var identifier = new TemplateByNameIdentifier(nameof(Returns_True_On_CreateTemplateByNameRequest));
-            TemplateCreatorMock.Setup(x => x.SupportsName(It.IsAny<string>())).Returns(true);
+            TemplateCreatorMock.SupportsName(Arg.Any<string>()).Returns(true);
 
             // Act
             var result = sut.Supports(identifier);

--- a/src/TemplateProviders.ChildTemplateProvider.Tests/ProviderComponent/ProviderComponentTests.cs
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/ProviderComponent/ProviderComponentTests.cs
@@ -2,6 +2,6 @@
 
 public partial class ProviderComponentTests
 {
-    protected ProviderComponent CreateSut() => new(new[] { TemplateCreatorMock.Object });
-    protected Mock<ITemplateCreator> TemplateCreatorMock { get; } = new();
+    protected ProviderComponent CreateSut() => new(new[] { TemplateCreatorMock });
+    protected ITemplateCreator TemplateCreatorMock { get; } = Substitute.For<ITemplateCreator>();
 }

--- a/src/TemplateProviders.ChildTemplateProvider.Tests/TemplateFramework.TemplateProviders.ChildTemplateProvider.Tests.csproj
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/TemplateFramework.TemplateProviders.ChildTemplateProvider.Tests.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -50,7 +50,7 @@
     <Using Include="CommunityToolkit.Diagnostics" />
     <Using Include="FluentAssertions" />
     <Using Include="Microsoft.Extensions.DependencyInjection" />
-    <Using Include="Moq" />
+    <Using Include="NSubstitute" />
     <Using Include="System.Globalization" />
     <Using Include="System.Text" />
     <Using Include="TemplateFramework.Abstractions" />

--- a/src/TemplateProviders.ChildTemplateProvider/TemplateFramework.TemplateProviders.ChildTemplateProvider.csproj
+++ b/src/TemplateProviders.ChildTemplateProvider/TemplateFramework.TemplateProviders.ChildTemplateProvider.csproj
@@ -10,6 +10,9 @@
     <PackageTags>templateengine;codegeneration</PackageTags>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/pauldeen79/TemplateFramework</RepositoryUrl>
+    <!-- Used by code coverage -->
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TemplateProviders.CompiledTemplateProvider.Tests/Extensions/ServiceCollectionExtensionsTests.AddTemplateFrameworkCompiledTemplateProvider.cs
+++ b/src/TemplateProviders.CompiledTemplateProvider.Tests/Extensions/ServiceCollectionExtensionsTests.AddTemplateFrameworkCompiledTemplateProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.TemplateProviders.CompiledTemplateProvider.Tests.Extensions;
+namespace TemplateFramework.TemplateProviders.CompiledTemplateProvider.Tests.Extensions;
 
 public class ServiceCollectionExtensionsTests
 {
@@ -12,9 +12,9 @@ public class ServiceCollectionExtensionsTests
                 .AddTemplateFramework()
                 .AddTemplateFrameworkCompiledTemplateProvider()
                 .AddTemplateFrameworkRuntime()
-                .AddSingleton(new Mock<IAssemblyInfoContextService>().Object)
-                .AddSingleton(new Mock<ITemplateFactory>().Object)
-                .AddSingleton(new Mock<ITemplateComponentRegistryPluginFactory>().Object)
+                .AddSingleton(Substitute.For<IAssemblyInfoContextService>())
+                .AddSingleton(Substitute.For<ITemplateFactory>())
+                .AddSingleton(Substitute.For<ITemplateComponentRegistryPluginFactory>())
                 .BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
 
             // Assert

--- a/src/TemplateProviders.CompiledTemplateProvider.Tests/IntegrationTests.cs
+++ b/src/TemplateProviders.CompiledTemplateProvider.Tests/IntegrationTests.cs
@@ -6,15 +6,15 @@ public class IntegrationTests
     public void Can_Render_Template_From_CompiledTemplateProvider()
     {
         // Arrange
-        var templateFactoryMock = new Mock<ITemplateFactory>();
-        templateFactoryMock.Setup(x => x.Create(It.IsAny<Type>())).Returns<Type>(t => Activator.CreateInstance(t)!);
+        var templateFactoryMock = Substitute.For<ITemplateFactory>();
+        templateFactoryMock.Create(Arg.Any<Type>()).Returns(x => Activator.CreateInstance(x.ArgAt<Type>(0))!);
         using var provider = new ServiceCollection()
             .AddTemplateFramework()
             .AddTemplateFrameworkRuntime()
             .AddTemplateFrameworkCompiledTemplateProvider()
-            .AddSingleton(new Mock<IAssemblyInfoContextService>().Object)
-            .AddSingleton(templateFactoryMock.Object)
-            .AddSingleton(new Mock<ITemplateComponentRegistryPluginFactory>().Object)
+            .AddSingleton(Substitute.For<IAssemblyInfoContextService>())
+            .AddSingleton(templateFactoryMock)
+            .AddSingleton(Substitute.For<ITemplateComponentRegistryPluginFactory>())
             .BuildServiceProvider(true);
         using var scope = provider.CreateScope();
         var templateProvider = scope.ServiceProvider.GetRequiredService<ITemplateProvider>();

--- a/src/TemplateProviders.CompiledTemplateProvider.Tests/ProviderComponent/ProviderComponentTests.Constructor.cs
+++ b/src/TemplateProviders.CompiledTemplateProvider.Tests/ProviderComponent/ProviderComponentTests.Constructor.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.TemplateProviders.CompiledTemplateProvider.Tests;
+namespace TemplateFramework.TemplateProviders.CompiledTemplateProvider.Tests;
 
 public partial class ProviderComponentTests
 {
@@ -8,7 +8,7 @@ public partial class ProviderComponentTests
         public void Throws_On_Null_AssemblyService()
         {
             // Act & Assert
-            this.Invoking(_ => new ProviderComponent(assemblyService: null!, CompiledTemplateFactoryMock.Object))
+            this.Invoking(_ => new ProviderComponent(assemblyService: null!, CompiledTemplateFactoryMock))
                 .Should().Throw<ArgumentNullException>().WithParameterName("assemblyService");
         }
 
@@ -16,7 +16,7 @@ public partial class ProviderComponentTests
         public void Throws_On_Null_Factory()
         {
             // Act & Assert
-            this.Invoking(_ => new ProviderComponent(AssemblyServiceMock.Object, templateFactory: null!))
+            this.Invoking(_ => new ProviderComponent(AssemblyServiceMock, templateFactory: null!))
                 .Should().Throw<ArgumentNullException>().WithParameterName("templateFactory");
         }
     }

--- a/src/TemplateProviders.CompiledTemplateProvider.Tests/ProviderComponent/ProviderComponentTests.Create.cs
+++ b/src/TemplateProviders.CompiledTemplateProvider.Tests/ProviderComponent/ProviderComponentTests.Create.cs
@@ -6,9 +6,8 @@ public partial class ProviderComponentTests
     {
         public Create()
         {
-            AssemblyServiceMock
-                .Setup(x => x.GetAssembly(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(GetType().Assembly);
+            AssemblyServiceMock.GetAssembly(Arg.Any<string>(), Arg.Any<string>())
+                               .Returns(GetType().Assembly);
         }
 
         [Fact]
@@ -29,7 +28,7 @@ public partial class ProviderComponentTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.Create(identifier: new Mock<ITemplateIdentifier>().Object))
+            sut.Invoking(x => x.Create(identifier: Substitute.For<ITemplateIdentifier>()))
                .Should().Throw<ArgumentException>().WithParameterName("identifier");
         }
 
@@ -38,7 +37,7 @@ public partial class ProviderComponentTests
         {
             // Arrange
             var sut = CreateSut();
-            CompiledTemplateFactoryMock.Setup(x => x.Create(It.IsAny<Type>())).Returns<Type>(t => Activator.CreateInstance(t)!);
+            CompiledTemplateFactoryMock.Create(Arg.Any<Type>()).Returns(x => Activator.CreateInstance(x.ArgAt<Type>(0))!);
 
             // Act
             var instance = sut.Create(new CompiledTemplateIdentifier(GetType().Assembly.FullName!, GetType().FullName!));

--- a/src/TemplateProviders.CompiledTemplateProvider.Tests/ProviderComponent/ProviderComponentTests.Supports.cs
+++ b/src/TemplateProviders.CompiledTemplateProvider.Tests/ProviderComponent/ProviderComponentTests.Supports.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.TemplateProviders.CompiledTemplateProvider.Tests;
+namespace TemplateFramework.TemplateProviders.CompiledTemplateProvider.Tests;
 
 public partial class ProviderComponentTests
 {
@@ -24,7 +24,7 @@ public partial class ProviderComponentTests
             var sut = CreateSut();
 
             // Act
-            var result = sut.Supports(new Mock<ITemplateIdentifier>().Object);
+            var result = sut.Supports(Substitute.For<ITemplateIdentifier>());
 
             // Assert
             result.Should().BeFalse();

--- a/src/TemplateProviders.CompiledTemplateProvider.Tests/ProviderComponent/ProviderComponentTests.cs
+++ b/src/TemplateProviders.CompiledTemplateProvider.Tests/ProviderComponent/ProviderComponentTests.cs
@@ -2,8 +2,8 @@
 
 public partial class ProviderComponentTests
 {
-    protected Mock<IAssemblyService> AssemblyServiceMock { get; } = new();
-    protected Mock<ITemplateFactory> CompiledTemplateFactoryMock { get; } = new();
+    protected IAssemblyService AssemblyServiceMock { get; } = Substitute.For<IAssemblyService>();
+    protected ITemplateFactory CompiledTemplateFactoryMock { get; } = Substitute.For<ITemplateFactory>();
 
-    protected ProviderComponent CreateSut() => new(AssemblyServiceMock.Object, CompiledTemplateFactoryMock.Object);
+    protected ProviderComponent CreateSut() => new(AssemblyServiceMock, CompiledTemplateFactoryMock);
 }

--- a/src/TemplateProviders.CompiledTemplateProvider.Tests/TemplateFramework.TemplateProviders.CompiledTemplateProvider.Tests.csproj
+++ b/src/TemplateProviders.CompiledTemplateProvider.Tests/TemplateFramework.TemplateProviders.CompiledTemplateProvider.Tests.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -48,7 +48,7 @@
   <ItemGroup>
     <Using Include="FluentAssertions" />
     <Using Include="Microsoft.Extensions.DependencyInjection" />
-    <Using Include="Moq" />
+    <Using Include="NSubstitute" />
     <Using Include="System.Text" />
     <Using Include="TemplateFramework.Abstractions" />
     <Using Include="TemplateFramework.Abstractions.Templates" />

--- a/src/TemplateProviders.CompiledTemplateProvider/TemplateFramework.TemplateProviders.CompiledTemplateProvider.csproj
+++ b/src/TemplateProviders.CompiledTemplateProvider/TemplateFramework.TemplateProviders.CompiledTemplateProvider.csproj
@@ -10,6 +10,9 @@
     <PackageTags>templateengine;codegeneration</PackageTags>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/pauldeen79/TemplateFramework</RepositoryUrl>
+    <!-- Used by code coverage -->
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TemplateProviders.StringTemplateProvider.Tests/ExpressionStringTemplateTests.cs
+++ b/src/TemplateProviders.StringTemplateProvider.Tests/ExpressionStringTemplateTests.cs
@@ -3,12 +3,12 @@
 public class ExpressionStringTemplateTests
 {
     protected const string Template = "Hello {Name}!";
-    protected Mock<IExpressionStringParser> ExpressionStringParserMock { get; } = new();
-    protected Mock<IFormattableStringParser> FormattableStringParserMock { get; } = new();
+    protected IExpressionStringParser ExpressionStringParserMock { get; } = Substitute.For<IExpressionStringParser>();
+    protected IFormattableStringParser FormattableStringParserMock { get; } = Substitute.For<IFormattableStringParser>();
     protected ExpressionStringTemplateIdentifier Identifier { get; } = new ExpressionStringTemplateIdentifier(Template, CultureInfo.CurrentCulture);
     protected ComponentRegistrationContext ComponentRegistrationContext { get; } = new();
 
-    protected ExpressionStringTemplate CreateSut() => new(Identifier, ExpressionStringParserMock.Object, FormattableStringParserMock.Object, ComponentRegistrationContext);
+    protected ExpressionStringTemplate CreateSut() => new(Identifier, ExpressionStringParserMock, FormattableStringParserMock, ComponentRegistrationContext);
 
     public class Constructor : ExpressionStringTemplateTests
     {
@@ -16,7 +16,7 @@ public class ExpressionStringTemplateTests
         public void Throws_On_Null_ExpressionStringTemplateIdentifier()
         {
             // Act & Assert
-            this.Invoking(_ => new ExpressionStringTemplate(expressionStringTemplateIdentifier: null!, ExpressionStringParserMock.Object, FormattableStringParserMock.Object, ComponentRegistrationContext))
+            this.Invoking(_ => new ExpressionStringTemplate(expressionStringTemplateIdentifier: null!, ExpressionStringParserMock, FormattableStringParserMock, ComponentRegistrationContext))
                 .Should().Throw<ArgumentNullException>().WithParameterName("expressionStringTemplateIdentifier");
         }
 
@@ -24,7 +24,7 @@ public class ExpressionStringTemplateTests
         public void Throws_On_Null_ExpressionStringParser()
         {
             // Act & Assert
-            this.Invoking(_ => new ExpressionStringTemplate(Identifier, expressionStringParser: null!, FormattableStringParserMock.Object, ComponentRegistrationContext))
+            this.Invoking(_ => new ExpressionStringTemplate(Identifier, expressionStringParser: null!, FormattableStringParserMock, ComponentRegistrationContext))
                 .Should().Throw<ArgumentNullException>().WithParameterName("expressionStringParser");
         }
 
@@ -32,7 +32,7 @@ public class ExpressionStringTemplateTests
         public void Throws_On_Null_FormattableStringParser()
         {
             // Act & Assert
-            this.Invoking(_ => new ExpressionStringTemplate(Identifier, ExpressionStringParserMock.Object, formattableStringParser: null!, ComponentRegistrationContext))
+            this.Invoking(_ => new ExpressionStringTemplate(Identifier, ExpressionStringParserMock, formattableStringParser: null!, ComponentRegistrationContext))
                 .Should().Throw<ArgumentNullException>().WithParameterName("formattableStringParser");
         }
 
@@ -40,7 +40,7 @@ public class ExpressionStringTemplateTests
         public void Throws_On_Null_ComponentRegistrationContext()
         {
             // Act & Assert
-            this.Invoking(_ => new ExpressionStringTemplate(Identifier, ExpressionStringParserMock.Object, FormattableStringParserMock.Object, componentRegistrationContext: null!))
+            this.Invoking(_ => new ExpressionStringTemplate(Identifier, ExpressionStringParserMock, FormattableStringParserMock, componentRegistrationContext: null!))
                 .Should().Throw<ArgumentNullException>().WithParameterName("componentRegistrationContext");
         }
     }
@@ -62,8 +62,7 @@ public class ExpressionStringTemplateTests
         public void Throws_On_NonSuccesful_Result_From_FormattableStringParser()
         {
             // Arrange
-            ExpressionStringParserMock
-                .Setup(x => x.Parse(It.IsAny<string>(), It.IsAny<IFormatProvider>(), It.IsAny<TemplateFrameworkStringContext>(), It.IsAny<IFormattableStringParser>()))
+            ExpressionStringParserMock.Parse(Arg.Any<string>(), Arg.Any<IFormatProvider>(), Arg.Any<TemplateFrameworkStringContext>(), Arg.Any<IFormattableStringParser>())
                 .Returns(Result<object?>.Error("Kaboom!"));
             var sut = CreateSut();
             var builder = new StringBuilder();
@@ -77,8 +76,7 @@ public class ExpressionStringTemplateTests
         public void Appends_Result_From_ExpressionStringParser_To_Builder_On_Succesful_Result()
         {
             // Arrange
-            ExpressionStringParserMock
-                .Setup(x => x.Parse(It.IsAny<string>(), It.IsAny<IFormatProvider>(), It.IsAny<TemplateFrameworkStringContext>(), It.IsAny<IFormattableStringParser>()))
+            ExpressionStringParserMock.Parse(Arg.Any<string>(), Arg.Any<IFormatProvider>(), Arg.Any<TemplateFrameworkStringContext>(), Arg.Any<IFormattableStringParser>())
                 .Returns(Result<object?>.Success("Parse result"));
             var sut = CreateSut();
             var builder = new StringBuilder();

--- a/src/TemplateProviders.StringTemplateProvider.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/TemplateProviders.StringTemplateProvider.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿namespace TemplateFramework.TemplateProviders.StringTemplateProvider.Tests.Extensions;
+namespace TemplateFramework.TemplateProviders.StringTemplateProvider.Tests.Extensions;
 
 public class ServiceCollectionExtensionsTests
 {
@@ -10,7 +10,7 @@ public class ServiceCollectionExtensionsTests
             .AddParsers()
             .AddTemplateFramework()
             .AddTemplateFrameworkStringTemplateProvider()
-            .AddSingleton(new Mock<ITemplateComponentRegistryPluginFactory>().Object)
+            .AddSingleton(Substitute.For<ITemplateComponentRegistryPluginFactory>())
             .BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
 
         // Assert

--- a/src/TemplateProviders.StringTemplateProvider.Tests/IntegrationTests.cs
+++ b/src/TemplateProviders.StringTemplateProvider.Tests/IntegrationTests.cs
@@ -10,7 +10,7 @@ public class IntegrationTests
             .AddParsers()
             .AddTemplateFramework()
             .AddTemplateFrameworkStringTemplateProvider()
-            .AddSingleton(new Mock<ITemplateComponentRegistryPluginFactory>().Object);
+            .AddSingleton(Substitute.For<ITemplateComponentRegistryPluginFactory>());
 
         using var provider = services.BuildServiceProvider(true);
         using var scope = provider.CreateScope();
@@ -53,25 +53,24 @@ public class IntegrationTests
     public void Can_Use_Custom_Registered_PlaceholderProcessor_In_FormattableStringTemplate()
     {
         // Arrange
-        var templateComponentRegistryPluginFactoryMock = new Mock<ITemplateComponentRegistryPluginFactory>();
+        var templateComponentRegistryPluginFactoryMock = Substitute.For<ITemplateComponentRegistryPluginFactory>();
 
         var services = new ServiceCollection()
             .AddParsers()
             .AddTemplateFramework()
             .AddTemplateFrameworkStringTemplateProvider()
-            .AddSingleton(templateComponentRegistryPluginFactoryMock.Object)
+            .AddSingleton(templateComponentRegistryPluginFactoryMock)
             .AddScoped<ITemplateComponentRegistryPlugin, TestTemplateComponentRegistryPlugin>();
 
         using var provider = services.BuildServiceProvider(true);
         using var scope = provider.CreateScope();
 
-        templateComponentRegistryPluginFactoryMock
-            .Setup(x => x.Create(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-            .Returns<string, string, string>((_, className, _)
+        templateComponentRegistryPluginFactoryMock.Create(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns(args
                 => scope.ServiceProvider.GetServices<ITemplateComponentRegistryPlugin>()
                     .OfType<TestTemplateComponentRegistryPlugin>()
-                    .FirstOrDefault(x => x.GetType().FullName == className)
-                        ?? throw new NotSupportedException($"Unsupported template component registry plug-in type: {className}"));
+                    .FirstOrDefault(x => x.GetType().FullName == args.ArgAt<string>(1))
+                        ?? throw new NotSupportedException($"Unsupported template component registry plug-in type: {args.ArgAt<string>(1)}"));
 
         var builder = new StringBuilder();
         var templateEngine = scope.ServiceProvider.GetRequiredService<ITemplateEngine>();
@@ -98,13 +97,13 @@ public class IntegrationTests
     public void Can_Use_Expression_In_Placeholder_In_FormattableStringTemplate()
     {
         // Arrange
-        var templateComponentRegistryPluginFactoryMock = new Mock<ITemplateComponentRegistryPluginFactory>();
+        var templateComponentRegistryPluginFactoryMock = Substitute.For<ITemplateComponentRegistryPluginFactory>();
 
         var services = new ServiceCollection()
             .AddParsers()
             .AddTemplateFramework()
             .AddTemplateFrameworkStringTemplateProvider()
-            .AddSingleton(templateComponentRegistryPluginFactoryMock.Object);
+            .AddSingleton(templateComponentRegistryPluginFactoryMock);
 
         using var provider = services.BuildServiceProvider(true);
         using var scope = provider.CreateScope();
@@ -131,25 +130,24 @@ public class IntegrationTests
     public void Can_Use_Custom_Registered_FunctionResultParser_In_FormattableStringTemplate()
     {
         // Arrange
-        var templateComponentRegistryPluginFactoryMock = new Mock<ITemplateComponentRegistryPluginFactory>();
+        var templateComponentRegistryPluginFactoryMock = Substitute.For<ITemplateComponentRegistryPluginFactory>();
 
         var services = new ServiceCollection()
             .AddParsers()
             .AddTemplateFramework()
             .AddTemplateFrameworkStringTemplateProvider()
-            .AddSingleton(templateComponentRegistryPluginFactoryMock.Object)
+            .AddSingleton(templateComponentRegistryPluginFactoryMock)
             .AddScoped<ITemplateComponentRegistryPlugin, TestTemplateComponentRegistryPlugin>();
 
         using var provider = services.BuildServiceProvider(true);
         using var scope = provider.CreateScope();
 
-        templateComponentRegistryPluginFactoryMock
-            .Setup(x => x.Create(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-            .Returns<string, string, string>((_, className, _)
+        templateComponentRegistryPluginFactoryMock.Create(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns(args
                 => scope.ServiceProvider.GetServices<ITemplateComponentRegistryPlugin>()
                     .OfType<TestTemplateComponentRegistryPlugin>()
-                    .FirstOrDefault(x => x.GetType().FullName == className)
-                        ?? throw new NotSupportedException($"Unsupported template component registry plug-in type: {className}"));
+                    .FirstOrDefault(x => x.GetType().FullName == args.ArgAt<string>(1))
+                        ?? throw new NotSupportedException($"Unsupported template component registry plug-in type: {args.ArgAt<string>(1)}"));
 
         var builder = new StringBuilder();
         var templateEngine = scope.ServiceProvider.GetRequiredService<ITemplateEngine>();
@@ -176,25 +174,24 @@ public class IntegrationTests
     public void Can_Use_Custom_Registered_FunctionResultParser_In_ExpressionStringTemplate()
     {
         // Arrange
-        var templateComponentRegistryPluginFactoryMock = new Mock<ITemplateComponentRegistryPluginFactory>();
+        var templateComponentRegistryPluginFactoryMock = Substitute.For<ITemplateComponentRegistryPluginFactory>();
 
         var services = new ServiceCollection()
             .AddParsers()
             .AddTemplateFramework()
             .AddTemplateFrameworkStringTemplateProvider()
-            .AddSingleton(templateComponentRegistryPluginFactoryMock.Object)
+            .AddSingleton(templateComponentRegistryPluginFactoryMock)
             .AddScoped<ITemplateComponentRegistryPlugin, TestTemplateComponentRegistryPlugin>();
 
         using var provider = services.BuildServiceProvider(true);
         using var scope = provider.CreateScope();
 
-        templateComponentRegistryPluginFactoryMock
-            .Setup(x => x.Create(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-            .Returns<string, string, string>((_, className, _)
+        templateComponentRegistryPluginFactoryMock.Create(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns(args
                 => scope.ServiceProvider.GetServices<ITemplateComponentRegistryPlugin>()
                     .OfType<TestTemplateComponentRegistryPlugin>()
-                    .FirstOrDefault(x => x.GetType().FullName == className)
-                        ?? throw new NotSupportedException($"Unsupported template component registry plug-in type: {className}"));
+                    .FirstOrDefault(x => x.GetType().FullName == args.ArgAt<string>(1))
+                        ?? throw new NotSupportedException($"Unsupported template component registry plug-in type: {args.ArgAt<string>(1)}"));
 
         var builder = new StringBuilder();
         var templateEngine = scope.ServiceProvider.GetRequiredService<ITemplateEngine>();
@@ -221,13 +218,13 @@ public class IntegrationTests
     public void Can_Use_ExpressionFramework_In_FormattableStringTemplate()
     {
         // Arrange
-        var templateComponentRegistryPluginFactoryMock = new Mock<ITemplateComponentRegistryPluginFactory>();
+        var templateComponentRegistryPluginFactoryMock = Substitute.For<ITemplateComponentRegistryPluginFactory>();
 
         var services = new ServiceCollection()
             .AddParsers()
             .AddTemplateFramework()
             .AddTemplateFrameworkStringTemplateProvider()
-            .AddSingleton(templateComponentRegistryPluginFactoryMock.Object)
+            .AddSingleton(templateComponentRegistryPluginFactoryMock)
             .AddExpressionParser();
 
         using var provider = services.BuildServiceProvider(true);
@@ -255,13 +252,13 @@ public class IntegrationTests
     public void Can_Use_ExpressionFramework_In_ExpressionStringTemplate()
     {
         // Arrange
-        var templateComponentRegistryPluginFactoryMock = new Mock<ITemplateComponentRegistryPluginFactory>();
+        var templateComponentRegistryPluginFactoryMock = Substitute.For<ITemplateComponentRegistryPluginFactory>();
 
         var services = new ServiceCollection()
             .AddParsers()
             .AddTemplateFramework()
             .AddTemplateFrameworkStringTemplateProvider()
-            .AddSingleton(templateComponentRegistryPluginFactoryMock.Object)
+            .AddSingleton(templateComponentRegistryPluginFactoryMock)
             .AddExpressionParser();
 
         using var provider = services.BuildServiceProvider(true);

--- a/src/TemplateProviders.StringTemplateProvider.Tests/ProviderComponentTests.cs
+++ b/src/TemplateProviders.StringTemplateProvider.Tests/ProviderComponentTests.cs
@@ -2,11 +2,11 @@
 
 public class ProviderComponentTests
 {
-    protected Mock<IExpressionStringParser> ExpressionStringParserMock { get; } = new();
-    protected Mock<IFormattableStringParser> FormattableStringParserMock { get; } = new();
+    protected IExpressionStringParser ExpressionStringParserMock { get; } = Substitute.For<IExpressionStringParser>();
+    protected IFormattableStringParser FormattableStringParserMock { get; } = Substitute.For<IFormattableStringParser>();
     protected ComponentRegistrationContext ComponentRegistrationContext { get; } = new();
 
-    protected ProviderComponent CreateSut() => new(ExpressionStringParserMock.Object, FormattableStringParserMock.Object, ComponentRegistrationContext);
+    protected ProviderComponent CreateSut() => new(ExpressionStringParserMock, FormattableStringParserMock, ComponentRegistrationContext);
 
     public class Constructor : ProviderComponentTests
     {
@@ -14,7 +14,7 @@ public class ProviderComponentTests
         public void Throws_On_Null_ExpressionStringParser()
         {
             // Act & Assert
-            this.Invoking(_ => new ProviderComponent(expressionStringParser: null!, FormattableStringParserMock.Object, ComponentRegistrationContext))
+            this.Invoking(_ => new ProviderComponent(expressionStringParser: null!, FormattableStringParserMock, ComponentRegistrationContext))
                 .Should().Throw<ArgumentNullException>().WithParameterName("expressionStringParser");
         }
 
@@ -22,7 +22,7 @@ public class ProviderComponentTests
         public void Throws_On_Null_FormattableStringParser()
         {
             // Act & Assert
-            this.Invoking(_ => new ProviderComponent(ExpressionStringParserMock.Object, formattableStringParser: null!, ComponentRegistrationContext))
+            this.Invoking(_ => new ProviderComponent(ExpressionStringParserMock, formattableStringParser: null!, ComponentRegistrationContext))
                 .Should().Throw<ArgumentNullException>().WithParameterName("formattableStringParser");
         }
 
@@ -30,7 +30,7 @@ public class ProviderComponentTests
         public void Throws_On_Null_ComponentRegistrationContext()
         {
             // Act & Assert
-            this.Invoking(_ => new ProviderComponent(ExpressionStringParserMock.Object, FormattableStringParserMock.Object, componentRegistrationContext: null!))
+            this.Invoking(_ => new ProviderComponent(ExpressionStringParserMock, FormattableStringParserMock, componentRegistrationContext: null!))
                 .Should().Throw<ArgumentNullException>().WithParameterName("componentRegistrationContext");
         }
     }
@@ -57,7 +57,7 @@ public class ProviderComponentTests
             var sut = CreateSut();
 
             // Act
-            var result = sut.Supports(new Mock<ITemplateIdentifier>().Object);
+            var result = sut.Supports(Substitute.For<ITemplateIdentifier>());
 
             // Assert
             result.Should().BeFalse();
@@ -110,7 +110,7 @@ public class ProviderComponentTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.Create(identifier: new Mock<ITemplateIdentifier>().Object))
+            sut.Invoking(x => x.Create(identifier: Substitute.For<ITemplateIdentifier>()))
                .Should().Throw<NotSupportedException>();
         }
         
@@ -149,7 +149,7 @@ public class ProviderComponentTests
         public void Clears_PlaceholderProcessors()
         {
             // Arrange
-            ComponentRegistrationContext.PlaceholderProcessors.Add(new Mock<IPlaceholderProcessor>().Object);
+            ComponentRegistrationContext.PlaceholderProcessors.Add(Substitute.For<IPlaceholderProcessor>());
             var sut = CreateSut();
 
             // Act
@@ -163,7 +163,7 @@ public class ProviderComponentTests
         public void Clears_FunctionResultParsers()
         {
             // Arrange
-            ComponentRegistrationContext.FunctionResultParsers.Add(new Mock<IFunctionResultParser>().Object);
+            ComponentRegistrationContext.FunctionResultParsers.Add(Substitute.For<IFunctionResultParser>());
             var sut = CreateSut();
 
             // Act

--- a/src/TemplateProviders.StringTemplateProvider.Tests/TemplateFramework.TemplateProviders.StringTemplateProvider.Tests.csproj
+++ b/src/TemplateProviders.StringTemplateProvider.Tests/TemplateFramework.TemplateProviders.StringTemplateProvider.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="pauldeen79.ExpressionFramework.Domain.Parser" Version="0.5.14" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
@@ -41,7 +41,7 @@
     <Using Include="ExpressionFramework.Parser" />
     <Using Include="FluentAssertions" />
     <Using Include="Microsoft.Extensions.DependencyInjection" />
-    <Using Include="Moq" />
+    <Using Include="NSubstitute" />
     <Using Include="System.Globalization" />
     <Using Include="System.Text" />
     <Using Include="TemplateFramework.Abstractions" />

--- a/src/TemplateProviders.StringTemplateProvider.Tests/TemplateFrameworkContextPlaceholderProcessorTests.cs
+++ b/src/TemplateProviders.StringTemplateProvider.Tests/TemplateFrameworkContextPlaceholderProcessorTests.cs
@@ -3,7 +3,7 @@
 public class TemplateFrameworkContextPlaceholderProcessorTests
 {
     protected ComponentRegistrationContext ComponentRegistrationContext { get; } = new();
-    protected Mock<IFormattableStringParser> FormattableStringParserMock { get; } = new();
+    protected IFormattableStringParser FormattableStringParserMock { get; } = Substitute.For<IFormattableStringParser>();
 
     protected TemplateFrameworkContextPlaceholderProcessor CreateSut() => new();
 
@@ -16,7 +16,7 @@ public class TemplateFrameworkContextPlaceholderProcessorTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.Process(value: null!, CultureInfo.CurrentCulture, null, FormattableStringParserMock.Object))
+            sut.Invoking(x => x.Process(value: null!, CultureInfo.CurrentCulture, null, FormattableStringParserMock))
                .Should().Throw<ArgumentNullException>().WithParameterName("value");
         }
 
@@ -27,7 +27,7 @@ public class TemplateFrameworkContextPlaceholderProcessorTests
             var sut = CreateSut();
 
             // Act & Assert
-            sut.Invoking(x => x.Process("some template", formatProvider: null!, null, FormattableStringParserMock.Object))
+            sut.Invoking(x => x.Process("some template", formatProvider: null!, null, FormattableStringParserMock))
                .Should().Throw<ArgumentNullException>().WithParameterName("formatProvider");
         }
 
@@ -50,7 +50,7 @@ public class TemplateFrameworkContextPlaceholderProcessorTests
             var context = "some context that's not of type TemplateFrameworkFormattableStringContext";
 
             // Act
-            var result = sut.Process("some template", CultureInfo.CurrentCulture, context, FormattableStringParserMock.Object);
+            var result = sut.Process("some template", CultureInfo.CurrentCulture, context, FormattableStringParserMock);
 
             // Assert
             result.Status.Should().Be(ResultStatus.Continue);
@@ -68,7 +68,7 @@ public class TemplateFrameworkContextPlaceholderProcessorTests
             var context = new TemplateFrameworkStringContext(parametersDictionary, ComponentRegistrationContext, false);
 
             // Act
-            var result = sut.Process("Name", CultureInfo.CurrentCulture, context, FormattableStringParserMock.Object);
+            var result = sut.Process("Name", CultureInfo.CurrentCulture, context, FormattableStringParserMock);
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -87,7 +87,7 @@ public class TemplateFrameworkContextPlaceholderProcessorTests
             var context = new TemplateFrameworkStringContext(parametersDictionary, ComponentRegistrationContext, false);
 
             // Act
-            var result = sut.Process("Name", CultureInfo.CurrentCulture, context, FormattableStringParserMock.Object);
+            var result = sut.Process("Name", CultureInfo.CurrentCulture, context, FormattableStringParserMock);
 
             // Assert
             result.Status.Should().Be(ResultStatus.Ok);
@@ -103,7 +103,7 @@ public class TemplateFrameworkContextPlaceholderProcessorTests
             var context = new TemplateFrameworkStringContext(parametersDictionary, ComponentRegistrationContext, false);
 
             // Act
-            var result = sut.Process("Name", CultureInfo.CurrentCulture, context, FormattableStringParserMock.Object);
+            var result = sut.Process("Name", CultureInfo.CurrentCulture, context, FormattableStringParserMock);
 
             // Assert
             result.Status.Should().Be(ResultStatus.Continue);
@@ -118,7 +118,7 @@ public class TemplateFrameworkContextPlaceholderProcessorTests
             var context = new TemplateFrameworkStringContext(parametersDictionary, ComponentRegistrationContext, false);
 
             // Act
-            _ = sut.Process("Name", CultureInfo.CurrentCulture, context, FormattableStringParserMock.Object);
+            _ = sut.Process("Name", CultureInfo.CurrentCulture, context, FormattableStringParserMock);
 
             // Assert
             context.ParameterNamesList.Should().BeEquivalentTo("Name");
@@ -133,7 +133,7 @@ public class TemplateFrameworkContextPlaceholderProcessorTests
             var context = new TemplateFrameworkStringContext(parametersDictionary, ComponentRegistrationContext, false);
 
             // Act
-            _ = sut.Process("__Name", CultureInfo.CurrentCulture, context, FormattableStringParserMock.Object);
+            _ = sut.Process("__Name", CultureInfo.CurrentCulture, context, FormattableStringParserMock);
 
             // Assert
             context.ParameterNamesList.Should().BeEmpty();

--- a/src/TemplateProviders.StringTemplateProvider.Tests/TestTemplateComponentRegistryPlugin.cs
+++ b/src/TemplateProviders.StringTemplateProvider.Tests/TestTemplateComponentRegistryPlugin.cs
@@ -13,17 +13,17 @@ public sealed class TestTemplateComponentRegistryPlugin : ITemplateComponentRegi
 
     public void Initialize(ITemplateComponentRegistry registry)
     {
-        var processorProcessorMock = new Mock<IPlaceholderProcessor>();
-        processorProcessorMock
-            .Setup(x => x.Process(It.IsAny<string>(), It.IsAny<IFormatProvider>(), It.IsAny<object?>(), It.IsAny<IFormattableStringParser>()))
-            .Returns<string, IFormatProvider, object?, IFormattableStringParser>((value, _, _, _) => value == "__test" ? Result<string>.Success("Hello world!") : Result<string>.Continue());
+        var processorProcessorMock = Substitute.For<IPlaceholderProcessor>();
+        processorProcessorMock.Process(Arg.Any<string>(), Arg.Any<IFormatProvider>(), Arg.Any<object?>(), Arg.Any<IFormattableStringParser>())
+            .Returns(args => args.ArgAt<string>(0) == "__test"
+                ? Result<string>.Success("Hello world!")
+                : Result<string>.Continue());
 
-        var functionResultParserMock = new Mock<IFunctionResultParser>();
-        functionResultParserMock
-            .Setup(x => x.Parse(It.IsAny<FunctionParseResult>(), It.IsAny<object?>(), It.IsAny<IFunctionParseResultEvaluator>(), It.IsAny<IExpressionParser>()))
-            .Returns<FunctionParseResult, object?, IFunctionParseResultEvaluator, IExpressionParser>((result, _, _, _) =>
+        var functionResultParserMock = Substitute.For<IFunctionResultParser>();
+        functionResultParserMock.Parse(Arg.Any<FunctionParseResult>(), Arg.Any<object?>(), Arg.Any<IFunctionParseResultEvaluator>(), Arg.Any<IExpressionParser>())
+            .Returns(args =>
             {
-                if (result.FunctionName == "MyFunction")
+                if (args.ArgAt<FunctionParseResult>(0).FunctionName == "MyFunction")
                 {
                     return Result<object?>.Success("Hello world!");
                 }
@@ -31,7 +31,7 @@ public sealed class TestTemplateComponentRegistryPlugin : ITemplateComponentRegi
                 return Result<object?>.Continue();
             });
 
-        ComponentRegistrationContext.PlaceholderProcessors.Add(processorProcessorMock.Object);
-        ComponentRegistrationContext.FunctionResultParsers.Add(functionResultParserMock.Object);
+        ComponentRegistrationContext.PlaceholderProcessors.Add(processorProcessorMock);
+        ComponentRegistrationContext.FunctionResultParsers.Add(functionResultParserMock);
     }
 }

--- a/src/TemplateProviders.StringTemplateProvider/TemplateFramework.TemplateProviders.StringTemplateProvider.csproj
+++ b/src/TemplateProviders.StringTemplateProvider/TemplateFramework.TemplateProviders.StringTemplateProvider.csproj
@@ -10,6 +10,9 @@
     <PackageTags>templateengine;codegeneration</PackageTags>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/pauldeen79/TemplateFramework</RepositoryUrl>
+    <!-- Used by code coverage -->
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Used this tool to do  automate the plumbing:
https://github.com/Creastoff/Moqstitute

After that, had to do some manual stuff, like replacing instanciation of mock objects like this
protected ISomething SomethingMock { get; } = new();

Which previously worked:
protected Mock<ISomething> SomethingMock { get; } =new();

Documentation used:
https://nsubstitute.github.io/

Note that I have included a test helper previously stored in CrossCutting.Common.Testing, which previously was tied to Moq. I refactored it, so it's compatible with any mocking librar now. (you have to pass a factory to create classes from types)