### PR TITLE
Improve error messages on unkown templates

### DIFF
--- a/src/TemplateProviders.ChildTemplateProvider.Tests/IntegrationTests.cs
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/IntegrationTests.cs
@@ -57,4 +57,44 @@ public class IntegrationTests : TestBase
         // Assert
         generationEnvironment.Builder.Contents.Should().HaveCount(4);
     }
+
+    [Fact]
+    public void Rendering_Unknown_Template_By_Name_Gives_Clear_ErrorMessage_What_Is_Wrong()
+    {
+        // Arrange
+        var templateComponentRegistryPluginFactory = Fixture.Freeze<ITemplateComponentRegistryPluginFactory>();
+        using var provider = new ServiceCollection()
+            .AddTemplateFramework()
+            .AddTemplateFrameworkChildTemplateProvider()
+            .AddChildTemplate("MyTemplate", _ => new TestData.PlainTemplateWithTemplateContext(context => "Context IsRootContext: " + context.IsRootContext))
+            .AddSingleton(templateComponentRegistryPluginFactory)
+            .BuildServiceProvider(true);
+        using var scope = provider.CreateScope();
+        var engine = scope.ServiceProvider.GetRequiredService<ITemplateEngine>();
+        var generationEnvironment = new MultipleContentBuilder();
+
+        // Act & Assert
+        engine.Invoking(x => x.Render(new RenderTemplateRequest(new TemplateByNameIdentifier("Unknown"), generationEnvironment)))
+              .Should().Throw<NotSupportedException>().WithMessage("Template with name Unknown is not supported");
+    }
+
+    [Fact]
+    public void Rendering_Unknown_Template_By_Model_Gives_Clear_ErrorMessage_What_Is_Wrong()
+    {
+        // Arrange
+        var templateComponentRegistryPluginFactory = Fixture.Freeze<ITemplateComponentRegistryPluginFactory>();
+        using var provider = new ServiceCollection()
+            .AddTemplateFramework()
+            .AddTemplateFrameworkChildTemplateProvider()
+            .AddChildTemplate("MyTemplate", _ => new TestData.PlainTemplateWithTemplateContext(context => "Context IsRootContext: " + context.IsRootContext))
+            .AddSingleton(templateComponentRegistryPluginFactory)
+            .BuildServiceProvider(true);
+        using var scope = provider.CreateScope();
+        var engine = scope.ServiceProvider.GetRequiredService<ITemplateEngine>();
+        var generationEnvironment = new MultipleContentBuilder();
+
+        // Act & Assert
+        engine.Invoking(x => x.Render(new RenderTemplateRequest(new TemplateByModelIdentifier("Unknown"), generationEnvironment)))
+              .Should().Throw<NotSupportedException>().WithMessage("Model of type System.String is not supported");
+    }
 }

--- a/src/TemplateProviders.ChildTemplateProvider.Tests/ProviderComponentTests.cs
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/ProviderComponentTests.cs
@@ -133,7 +133,7 @@ public class ProviderComponentTests : TestBase<ProviderComponent>
 
             // Act & Assert
             sut.Invoking(x => x.Create(new TemplateByNameIdentifier("test")))
-               .Should().Throw<NotSupportedException>().WithMessage("Name test is not supported");
+               .Should().Throw<NotSupportedException>().WithMessage("Template with name test is not supported");
         }
 
         [Fact]

--- a/src/TemplateProviders.ChildTemplateProvider/ProviderComponent.cs
+++ b/src/TemplateProviders.ChildTemplateProvider/ProviderComponent.cs
@@ -43,13 +43,12 @@ public sealed class ProviderComponent : ITemplateProviderComponent
         var creator = _childTemplateCreators.FirstOrDefault(x => x.SupportsName(name));
         if (creator is null)
         {
-            throw new NotSupportedException($"Name {name} is not supported");
+            throw new NotSupportedException($"Template with name {name} is not supported");
         }
 
         return creator.CreateByName(name) ?? throw new InvalidOperationException("Child template creator returned a null instance");
     }
 
     public bool Supports(ITemplateIdentifier identifier)
-        => identifier is TemplateByModelIdentifier m && _childTemplateCreators.Any(x => x.SupportsModel(m.Model))
-        || identifier is TemplateByNameIdentifier n && _childTemplateCreators.Any(x => x.SupportsName(n.Name));
+        => (identifier is TemplateByModelIdentifier || identifier is TemplateByNameIdentifier) && _childTemplateCreators.Any();
 }


### PR DESCRIPTION
Improve error messages when trying to render a template with an unknown name or model type

In the current situation, you would an the error message like this: Type of identifier TemplateFramework.TemplateProviders.ChildTemplateProvider.TemplateIdentifiers.TemplateByModelIdentifier is not supported

In the new situation, you would an the error messsage like this: Model of type XYZ is not supported
or Template with name XYZ is not supported