### PR TITLE
Small improvements

### DIFF
--- a/src/Core.Tests/TemplateInitializerComponents/ModelInitializerTests.cs
+++ b/src/Core.Tests/TemplateInitializerComponents/ModelInitializerTests.cs
@@ -35,7 +35,7 @@ public class ModelInitializerTests
             var template = new TestData.TemplateWithModel<string>(_ => { });
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), model, new StringBuilder(), DefaultFilename);
             var engineContext = new TemplateEngineContext(request, templateEngine, templateProvider, template);
-            valueConverter.Convert(Arg.Any<object?>(), Arg.Any<Type>()).Returns(x => x.Args()[0]);
+            valueConverter.Convert(Arg.Any<object?>(), Arg.Any<Type>(), Arg.Any<ITemplateEngineContext>()).Returns(x => x.Args()[0]);
 
             // Act
             sut.Initialize(engineContext);

--- a/src/Core.Tests/TemplateInitializerComponents/ParameterInitializerTests.cs
+++ b/src/Core.Tests/TemplateInitializerComponents/ParameterInitializerTests.cs
@@ -35,7 +35,7 @@ public class ParameterInitializerTests
             var template = new PlainTemplateWithAdditionalParameters();
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), new StringBuilder(), DefaultFilename, additionalParameters);
             var engineContext = new TemplateEngineContext(request, templateEngine, templateProvider, template);
-            valueConverter.Convert(Arg.Any<object?>(), Arg.Any<Type>()).Returns(x => x.Args()[0]);
+            valueConverter.Convert(Arg.Any<object?>(), Arg.Any<Type>(), Arg.Any<ITemplateEngineContext>()).Returns(x => x.Args()[0]);
 
             // Act
             sut.Initialize(engineContext);
@@ -55,8 +55,8 @@ public class ParameterInitializerTests
             var additionalParameters = new { AdditionalParameter = "?" };
             var template = new PlainTemplateWithAdditionalParameters();
             object? convertedValue = "Hello world!";
-            valueConverter.Convert(Arg.Any<object?>(), Arg.Any<Type>())
-                              .Returns(convertedValue);
+            valueConverter.Convert(Arg.Any<object?>(), Arg.Any<Type>(), Arg.Any<ITemplateEngineContext>())
+                          .Returns(convertedValue);
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), new StringBuilder(), DefaultFilename, additionalParameters);
             var engineContext = new TemplateEngineContext(request, templateEngine, templateProvider, template);
 
@@ -97,7 +97,7 @@ public class ParameterInitializerTests
             var template = new TestData.PlainTemplateWithModelAndAdditionalParameters<string>();
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), model, new StringBuilder(), DefaultFilename, additionalParameters);
             var engineContext = new TemplateEngineContext(request, templateEngine, templateProvider, template);
-            valueConverter.Convert(Arg.Any<object?>(), Arg.Any<Type>()).Returns(x => x.Args()[0]);
+            valueConverter.Convert(Arg.Any<object?>(), Arg.Any<Type>(), Arg.Any<ITemplateEngineContext>()).Returns(x => x.Args()[0]);
 
             // Act
             sut.Initialize(engineContext);
@@ -119,7 +119,7 @@ public class ParameterInitializerTests
             var viewModel = new TestData.NonConstructableViewModel("Some value");
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), new StringBuilder(), DefaultFilename, additionalParameters: new { ViewModel = viewModel });
             var engineContext = new TemplateEngineContext(request, templateEngine, templateProvider, template);
-            valueConverter.Convert(Arg.Any<object?>(), Arg.Any<Type>()).Returns(x => x.Args()[0]);
+            valueConverter.Convert(Arg.Any<object?>(), Arg.Any<Type>(), Arg.Any<ITemplateEngineContext>()).Returns(x => x.Args()[0]);
 
             // Act
             sut.Initialize(engineContext);
@@ -140,7 +140,7 @@ public class ParameterInitializerTests
             var template = new TestData.PocoParameterizedTemplate();
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), new StringBuilder(), DefaultFilename, additionalParameters);
             var engineContext = new TemplateEngineContext(request, templateEngine, templateProvider, template);
-            valueConverter.Convert(Arg.Any<object?>(), Arg.Any<Type>()).Returns(x => x.Args()[0]);
+            valueConverter.Convert(Arg.Any<object?>(), Arg.Any<Type>(), Arg.Any<ITemplateEngineContext>()).Returns(x => x.Args()[0]);
             templateEngine.GetParameters(Arg.Any<object>()).Returns(new[] { new TemplateParameter(nameof(TestData.PocoParameterizedTemplate.Parameter), typeof(string)) });
 
             // Act
@@ -162,7 +162,7 @@ public class ParameterInitializerTests
             var template = new TestData.PocoParameterizedTemplate();
             var request = new RenderTemplateRequest(new TemplateInstanceIdentifier(template), new StringBuilder(), DefaultFilename, additionalParameters);
             var engineContext = new TemplateEngineContext(request, templateEngine, templateProvider, template);
-            valueConverter.Convert(Arg.Any<object?>(), Arg.Any<Type>()).Returns(x => x.Args()[0]);
+            valueConverter.Convert(Arg.Any<object?>(), Arg.Any<Type>(), Arg.Any<ITemplateEngineContext>()).Returns(x => x.Args()[0]);
             templateEngine.GetParameters(Arg.Any<object>()).Returns(new[] { new TemplateParameter(nameof(TestData.PocoParameterizedTemplate.Parameter), typeof(string)) });
 
             // Act & Assert

--- a/src/Core.Tests/ValueConverterTests.cs
+++ b/src/Core.Tests/ValueConverterTests.cs
@@ -15,15 +15,16 @@ public class ValueConverterTests
     {
         [Theory, AutoMockData]
         public void Returns_Input_Value_When_No_TemplateParameterConverter_Supports_The_Type(
-            [Frozen] ITemplateParameterConverter templateParameterConverter, 
+            [Frozen] ITemplateParameterConverter templateParameterConverter,
+            [Frozen] ITemplateEngineContext context,
             ValueConverter sut)
         {
             // Arrange
             var value = "Hello world!";
-            templateParameterConverter.TryConvert(Arg.Any<object?>(), Arg.Any<Type>(), out Arg.Any<object?>()).Returns(false);
+            templateParameterConverter.TryConvert(Arg.Any<object?>(), Arg.Any<Type>(), Arg.Any<ITemplateEngineContext>(), out Arg.Any<object?>()).Returns(false);
 
             // Act
-            var result = sut.Convert(value, value.GetType());
+            var result = sut.Convert(value, value.GetType(), context);
 
             // Assert
             result.Should().BeSameAs(value);
@@ -32,18 +33,19 @@ public class ValueConverterTests
         [Theory, AutoMockData]
         public void Returns_Converted_Value_When_TemplateParameterConverter_Supports_The_Type(
             [Frozen] ITemplateParameterConverter templateParameterConverter,
+            [Frozen] ITemplateEngineContext context,
             ValueConverter sut)
         {
             // Arrange
             var value = "Hello world!";
-            templateParameterConverter.TryConvert(Arg.Any<object?>(), Arg.Any<Type>(), out Arg.Any<object?>()).Returns(x =>
+            templateParameterConverter.TryConvert(Arg.Any<object?>(), Arg.Any<Type>(), Arg.Any<ITemplateEngineContext>(), out Arg.Any<object?>()).Returns(x =>
             {
-                x[2] = value.ToUpperInvariant();
+                x[3] = value.ToUpperInvariant();
                 return true;
             });
 
             // Act
-            var result = sut.Convert(value, value.GetType());
+            var result = sut.Convert(value, value.GetType(), context);
 
             // Assert
             result.Should().BeEquivalentTo(value.ToUpperInvariant());

--- a/src/Core/Abstractions/ITemplateParameterConverter.cs
+++ b/src/Core/Abstractions/ITemplateParameterConverter.cs
@@ -2,5 +2,5 @@
 
 public interface ITemplateParameterConverter
 {
-    bool TryConvert(object? value, Type type, out object? convertedValue);
+    bool TryConvert(object? value, Type type, ITemplateEngineContext context, out object? convertedValue);
 }

--- a/src/Core/Abstractions/IValueConverter.cs
+++ b/src/Core/Abstractions/IValueConverter.cs
@@ -2,5 +2,5 @@
 
 public interface IValueConverter
 {
-    object? Convert(object? value, Type type);
+    object? Convert(object? value, Type type, ITemplateEngineContext context);
 }

--- a/src/Core/TemplateInitializerComponents/ModelInitializerComponent.cs
+++ b/src/Core/TemplateInitializerComponents/ModelInitializerComponent.cs
@@ -21,7 +21,7 @@ public class ModelInitializerComponent : ITemplateInitializerComponent
         if (Array.Exists(templateType.GetInterfaces(), t => t.FullName?.StartsWith("TemplateFramework.Abstractions.IModelContainer", StringComparison.InvariantCulture) == true))
         {
             var modelProperty = templateType.GetProperty(nameof(IModelContainer<object?>.Model))!;
-            modelProperty.SetValue(context.Template, _converter.Convert(context.Model, modelProperty.PropertyType));
+            modelProperty.SetValue(context.Template, _converter.Convert(context.Model, modelProperty.PropertyType, context));
         }
     }
 }

--- a/src/Core/TemplateInitializerComponents/ParameterInitializerComponent.cs
+++ b/src/Core/TemplateInitializerComponents/ParameterInitializerComponent.cs
@@ -38,7 +38,7 @@ public class ParameterInitializerComponent : ITemplateInitializerComponent
                 continue;
             }
 
-            parameterizedTemplate.SetParameter(item.Key, _converter.Convert(item.Value, parameter.Type));
+            parameterizedTemplate.SetParameter(item.Key, _converter.Convert(item.Value, parameter.Type, context));
         }
     }
 
@@ -62,7 +62,7 @@ public class ParameterInitializerComponent : ITemplateInitializerComponent
                 continue;
             }
 
-            prop.SetValue(context.Template, _converter.Convert(item.Value, prop.PropertyType));
+            prop.SetValue(context.Template, _converter.Convert(item.Value, prop.PropertyType, context));
         }
     }
 }

--- a/src/Core/ValueConverter.cs
+++ b/src/Core/ValueConverter.cs
@@ -11,11 +11,14 @@ public class ValueConverter : IValueConverter
         _converters = converters;
     }
 
-    public object? Convert(object? value, Type type)
+    public object? Convert(object? value, Type type, ITemplateEngineContext context)
     {
+        Guard.IsNotNull(type);
+        Guard.IsNotNull(context);
+
         foreach (var converter in _converters)
         {
-            if (converter.TryConvert(value, type, out var convertedValue))
+            if (converter.TryConvert(value, type, context, out var convertedValue))
             {
                 return convertedValue;
             }

--- a/src/TemplateProviders.ChildTemplateProvider/Extensions/ServiceCollectionExtensions.cs
+++ b/src/TemplateProviders.ChildTemplateProvider/Extensions/ServiceCollectionExtensions.cs
@@ -8,7 +8,7 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddChildTemplate<T>(this IServiceCollection services, Type modelType) where T : class
         => services
-            .AddScoped<T>()
+            .AddTransient<T>()
             .AddScoped<ITemplateCreator>(provider => new TemplateCreator<T>(() => provider.GetRequiredService<T>(), modelType, null));
 
     public static IServiceCollection AddChildTemplate<T>(this IServiceCollection services, Type modelType, Func<IServiceProvider, T> templateFactory) where T : class
@@ -17,7 +17,7 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddChildTemplate<T>(this IServiceCollection services, string name) where T : class
         => services
-            .AddScoped<T>()
+            .AddTransient<T>()
             .AddScoped<ITemplateCreator>(provider => new TemplateCreator<T>(() => provider.GetRequiredService<T>(), null, name));
 
     public static IServiceCollection AddChildTemplate<T>(this IServiceCollection services, string name, Func<IServiceProvider, T> templateFactory) where T : class


### PR DESCRIPTION
- Change: Templates should be registered as transient, because they should not share their state (model)
- Added ITemplateEngineContext argument to value converter, so you can use something from the context in conversion