### PR TITLE
ICodeGenerationProvider and ISessionAwareComponent now use result-based return values

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,23 +197,24 @@ There is also an example in launchSettings.json of the TemplateFramework.Console
 In version 2.0, there are three breaking changes:
 
 ```C#
-ICodeGenerationProvider:
+//ICodeGenerationProvider:
 Task<object?> CreateAdditionalParameters();
 Task<object?> CreateModel();
 
-ISessionAwareComponent:
+//ISessionAwareComponent:
 Task StartSession(CancellationToken cancellationToken);
 ```
 
 has changed to
 
 ```C#
-ICodeGenerationProvider:
+//ICodeGenerationProvider:
 Task<Result<object?>> CreateAdditionalParameters(CancellationToken cancellationToken);
 Task<Result<object?>> CreateModel(CancellationToken cancellationToken);
 
-ISessionAwareComponent:
+//ISessionAwareComponent:
 Task<Result> StartSession(CancellationToken cancellationToken);
 ```
 
 This enables you to return error messages from model creation, instead of throwing exceptions.
+And while we are already breaking compatibility, the CancellationToken argument is also added to CreateAdditionalParameters and CreateModel.

--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ has changed to
 
 ```C#
 ICodeGenerationProvider:
-Task<Result<object?>> CreateAdditionalParameters();
-Task<Result<object?>> CreateModel();
+Task<Result<object?>> CreateAdditionalParameters(CancellationToken cancellationToken);
+Task<Result<object?>> CreateModel(CancellationToken cancellationToken);
 
 ISessionAwareComponent:
 Task<Result> StartSession(CancellationToken cancellationToken);

--- a/README.md
+++ b/README.md
@@ -194,18 +194,26 @@ tf template --formattablestring template.txt --dryrun --default myfile.txt --int
 There is also an example in launchSettings.json of the TemplateFramework.Console project, that uses a template provider plug-in of a unit test project.
 
 # Upgrading from 1.x to 2.0
-In version 2.0, there is one breaking change:
+In version 2.0, there are three breaking changes:
 
 ```C#
+ICodeGenerationProvider:
 Task<object?> CreateAdditionalParameters();
 Task<object?> CreateModel();
+
+ISessionAwareComponent:
+Task StartSession(CancellationToken cancellationToken);
 ```
 
 has changed to
 
 ```C#
+ICodeGenerationProvider:
 Task<Result<object?>> CreateAdditionalParameters();
 Task<Result<object?>> CreateModel();
+
+ISessionAwareComponent:
+Task<Result> StartSession(CancellationToken cancellationToken);
 ```
 
 This enables you to return error messages from model creation, instead of throwing exceptions.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Note that the following assemblies will be loaded from the host (Console) comman
 - TemplateFramework.TemplateProviders.CompiledTemplateProvider
 - TemplateFramework.TemplateProviders.StringTemplateProvider
 - CrossCutting.Common (3.13.0)
-- CrossCutting.Utilities.Parsers (5.4.1)
+- CrossCutting.Utilities.Parsers (6.2.0)
 - Microsoft.Extensions.DependencyInjection (9.0.0)
 - Microsoft.Extensions.DependencyInjection.Abstractions (9.0.0)
 
@@ -192,3 +192,20 @@ tf template --formattablestring template.txt --dryrun --default myfile.txt --int
 ```
 
 There is also an example in launchSettings.json of the TemplateFramework.Console project, that uses a template provider plug-in of a unit test project.
+
+# Upgrading from 1.x to 2.0
+In version 2.0, there is one breaking change:
+
+```C#
+Task<object?> CreateAdditionalParameters();
+Task<object?> CreateModel();
+```
+
+has changed to
+
+```C#
+Task<Result<object?>> CreateAdditionalParameters();
+Task<Result<object?>> CreateModel();
+```
+
+This enables you to return error messages from model creation, instead of throwing exceptions.

--- a/src/Abstractions/CodeGeneration/ICodeGenerationProvider.cs
+++ b/src/Abstractions/CodeGeneration/ICodeGenerationProvider.cs
@@ -8,6 +8,6 @@ public interface ICodeGenerationProvider
     Encoding Encoding { get; }
 
     Type GetGeneratorType();
-    Task<Result<object?>> CreateAdditionalParameters();
-    Task<Result<object?>> CreateModel();
+    Task<Result<object?>> CreateAdditionalParameters(CancellationToken cancellationToken);
+    Task<Result<object?>> CreateModel(CancellationToken cancellationToken);
 }

--- a/src/Abstractions/CodeGeneration/ICodeGenerationProvider.cs
+++ b/src/Abstractions/CodeGeneration/ICodeGenerationProvider.cs
@@ -8,6 +8,6 @@ public interface ICodeGenerationProvider
     Encoding Encoding { get; }
 
     Type GetGeneratorType();
-    Task<object?> CreateAdditionalParameters();
-    Task<object?> CreateModel();
+    Task<Result<object?>> CreateAdditionalParameters();
+    Task<Result<object?>> CreateModel();
 }

--- a/src/Abstractions/ISessionAwareComponent.cs
+++ b/src/Abstractions/ISessionAwareComponent.cs
@@ -2,5 +2,5 @@
 
 public interface ISessionAwareComponent
 {
-    Task StartSession(CancellationToken cancellationToken);
+    Task<Result> StartSession(CancellationToken cancellationToken);
 }

--- a/src/Console.Tests/Commands/RunTemplateCommandTests.cs
+++ b/src/Console.Tests/Commands/RunTemplateCommandTests.cs
@@ -75,6 +75,7 @@ public class RunTemplateCommandTests : TestBase<RunTemplateCommand>
             var templateProviderMock = Fixture.Freeze<ITemplateProvider>();
             var templateEngineMock = Fixture.Freeze<ITemplateEngine>();
             templateProviderMock.Create(Arg.Any<ITemplateIdentifier>()).Returns(templateInstance);
+            templateProviderMock.StartSession(Arg.Any<CancellationToken>()).Returns(Result.Continue());
             templateEngineMock.Render(Arg.Any<IRenderTemplateRequest>(), Arg.Any<CancellationToken>()).Returns(Result.Success());
             var sut = CreateSut();
 
@@ -94,6 +95,7 @@ public class RunTemplateCommandTests : TestBase<RunTemplateCommand>
             var fileSystemMock = Fixture.Freeze<IFileSystem>();
             var templateInstance = new TestData.PlainTemplateWithModelAndAdditionalParameters<string>();
             templateProviderMock.Create(Arg.Any<ITemplateIdentifier>()).Returns(templateInstance);
+            templateProviderMock.StartSession(Arg.Any<CancellationToken>()).Returns(Result.Continue());
             templateEngineMock.Render(Arg.Any<IRenderTemplateRequest>(), Arg.Any<CancellationToken>()).Returns(Result.Success());
             fileSystemMock.FileExists("myfile.txt").Returns(true);
             fileSystemMock.ReadAllText("myfile.txt", Arg.Any<Encoding>()).Returns("template contents");
@@ -115,6 +117,7 @@ public class RunTemplateCommandTests : TestBase<RunTemplateCommand>
             var fileSystemMock = Fixture.Freeze<IFileSystem>();
             var templateInstance = new TestData.PlainTemplateWithModelAndAdditionalParameters<string>();
             templateProviderMock.Create(Arg.Any<ITemplateIdentifier>()).Returns(templateInstance);
+            templateProviderMock.StartSession(Arg.Any<CancellationToken>()).Returns(Result.Continue());
             templateEngineMock.Render(Arg.Any<IRenderTemplateRequest>(), Arg.Any<CancellationToken>()).Returns(Result.Success());
             fileSystemMock.FileExists("myfile.txt").Returns(true);
             fileSystemMock.ReadAllText("myfile.txt", Arg.Any<Encoding>()).Returns("template contents");
@@ -135,6 +138,7 @@ public class RunTemplateCommandTests : TestBase<RunTemplateCommand>
             var templateProviderMock = Fixture.Freeze<ITemplateProvider>();
             var templateEngineMock = Fixture.Freeze<ITemplateEngine>();
             templateProviderMock.Create(Arg.Any<ITemplateIdentifier>()).Returns(templateInstance);
+            templateProviderMock.StartSession(Arg.Any<CancellationToken>()).Returns(Result.Continue());
             templateEngineMock.Render(Arg.Any<IRenderTemplateRequest>(), Arg.Any<CancellationToken>()).Returns(Result.Success());
             var sut = CreateSut();
 
@@ -158,6 +162,7 @@ public class RunTemplateCommandTests : TestBase<RunTemplateCommand>
             var templateEngineMock = Fixture.Freeze<ITemplateEngine>();
             var userInputMock = Fixture.Freeze<IUserInput>();
             templateProviderMock.Create(Arg.Any<ITemplateIdentifier>()).Returns(templateInstance);
+            templateProviderMock.StartSession(Arg.Any<CancellationToken>()).Returns(Result.Continue());
             templateEngineMock.GetParameters(Arg.Any<object>()).Returns(Result.Success<ITemplateParameter[]>([new TemplateParameter(nameof(TestData.PlainTemplateWithModelAndAdditionalParameters<string>.AdditionalParameter), typeof(string))]));
             templateEngineMock.Render(Arg.Any<IRenderTemplateRequest>(), Arg.Any<CancellationToken>()).Returns(Result.Success());
             var sut = CreateSut();
@@ -177,6 +182,7 @@ public class RunTemplateCommandTests : TestBase<RunTemplateCommand>
             var templateProviderMock = Fixture.Freeze<ITemplateProvider>();
             var templateEngineMock = Fixture.Freeze<ITemplateEngine>();
             templateProviderMock.Create(Arg.Any<ITemplateIdentifier>()).Returns(templateInstance);
+            templateProviderMock.StartSession(Arg.Any<CancellationToken>()).Returns(Result.Continue());
             templateEngineMock.GetParameters(Arg.Any<object>()).Returns(Result.Success<ITemplateParameter[]>([new TemplateParameter(nameof(TestData.PlainTemplateWithModelAndAdditionalParameters<string>.AdditionalParameter), typeof(string))]));
             var sut = CreateSut();
 
@@ -199,6 +205,7 @@ AdditionalParameter (System.String)
             var templateProviderMock = Fixture.Freeze<ITemplateProvider>();
             var templateEngineMock = Fixture.Freeze<ITemplateEngine>();
             templateProviderMock.Create(Arg.Any<ITemplateIdentifier>()).Returns(templateInstance);
+            templateProviderMock.StartSession(Arg.Any<CancellationToken>()).Returns(Result.Continue());
             templateEngineMock.GetParameters(Arg.Any<object>()).Returns(Result.Success<ITemplateParameter[]>([new TemplateParameter(nameof(TestData.PlainTemplateWithModelAndAdditionalParameters<string>.AdditionalParameter), typeof(string))]));
             var sut = CreateSut();
 
@@ -219,6 +226,7 @@ AdditionalParameter (System.String)
             var templateEngineMock = Fixture.Freeze<ITemplateEngine>();
             var fileSystemMock = Fixture.Freeze<IFileSystem>();
             templateProviderMock.Create(Arg.Any<ITemplateIdentifier>()).Returns(templateInstance);
+            templateProviderMock.StartSession(Arg.Any<CancellationToken>()).Returns(Result.Continue());
             templateEngineMock.GetParameters(Arg.Any<object>()).Returns(Result.Success<ITemplateParameter[]>([new TemplateParameter(nameof(TestData.PlainTemplateWithModelAndAdditionalParameters<string>.AdditionalParameter), typeof(string))]));
             fileSystemMock.FileExists("myfile.txt").Returns(false);
             var sut = CreateSut();
@@ -240,6 +248,7 @@ AdditionalParameter (System.String)
             var templateEngineMock = Fixture.Freeze<ITemplateEngine>();
             var fileSystemMock = Fixture.Freeze<IFileSystem>();
             templateProviderMock.Create(Arg.Any<ITemplateIdentifier>()).Returns(templateInstance);
+            templateProviderMock.StartSession(Arg.Any<CancellationToken>()).Returns(Result.Continue());
             templateEngineMock.GetParameters(Arg.Any<object>()).Returns(Result.Success<ITemplateParameter[]>([new TemplateParameter(nameof(TestData.PlainTemplateWithModelAndAdditionalParameters<string>.AdditionalParameter), typeof(string))]));
             fileSystemMock.FileExists("myfile.txt").Returns(false);
             var sut = CreateSut();

--- a/src/Core.CodeGeneration.Tests/CodeGenerationEngineTests.cs
+++ b/src/Core.CodeGeneration.Tests/CodeGenerationEngineTests.cs
@@ -64,7 +64,8 @@ public class CodeGenerationEngineTests : TestBase<CodeGenerationEngine>
             codeGenerationProvider.Path.Returns(TestData.BasePath);
             codeGenerationProvider.GetGeneratorType().Returns(GetType());
             codeGenerationProvider.CreateModel().Returns(Task.FromResult(Result.Continue<object?>()));
-            codeGenerationProvider.CreateAdditionalParameters().Returns(Task.FromResult(Result.Continue<object?>())); codeGenerationSettings.DryRun.Returns(false);
+            codeGenerationProvider.CreateAdditionalParameters().Returns(Task.FromResult(Result.Continue<object?>()));
+            codeGenerationSettings.DryRun.Returns(false);
             codeGenerationSettings.BasePath.Returns(TestData.BasePath);
             codeGenerationSettings.DefaultFilename.Returns("Filename.txt");
             templateEngine.Render(Arg.Any<IRenderTemplateRequest>(), Arg.Any<CancellationToken>()).Returns(Result.Success());
@@ -89,7 +90,8 @@ public class CodeGenerationEngineTests : TestBase<CodeGenerationEngine>
             codeGenerationProvider.Path.Returns(TestData.BasePath);
             codeGenerationProvider.GetGeneratorType().Returns(GetType());
             codeGenerationProvider.CreateModel().Returns(Task.FromResult(Result.Continue<object?>()));
-            codeGenerationProvider.CreateAdditionalParameters().Returns(Task.FromResult(Result.Continue<object?>())); codeGenerationSettings.DryRun.Returns(true);
+            codeGenerationProvider.CreateAdditionalParameters().Returns(Task.FromResult(Result.Continue<object?>()));
+            codeGenerationSettings.DryRun.Returns(true);
             codeGenerationSettings.DefaultFilename.Returns("Filename.txt");
             templateEngine.Render(Arg.Any<IRenderTemplateRequest>(), Arg.Any<CancellationToken>()).Returns(Result.Success());
             var sut = CreateSut();
@@ -146,6 +148,51 @@ public class CodeGenerationEngineTests : TestBase<CodeGenerationEngine>
             // Assert
             result.Status.Should().Be(ResultStatus.Error);
             counter.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task Returns_Non_Successful_Result_From_Model_Creation()
+        {
+            // Arrange
+            var codeGenerationProvider = Fixture.Freeze<ICodeGenerationProvider>();
+            var generationEnvironment = Fixture.Freeze<IGenerationEnvironment>();
+            var codeGenerationSettings = Fixture.Freeze<ICodeGenerationSettings>();
+            var templateEngine = Fixture.Freeze<ITemplateEngine>();
+            codeGenerationProvider.Encoding.Returns(Encoding.Latin1);
+            codeGenerationProvider.Path.Returns(TestData.BasePath);
+            codeGenerationProvider.GetGeneratorType().Returns(GetType());
+            codeGenerationProvider.CreateModel().Returns(Task.FromResult(Result.Error<object?>("Kaboom")));
+            var sut = CreateSut();
+
+            // Act
+            var result = await sut.Generate(codeGenerationProvider, generationEnvironment, codeGenerationSettings);
+
+            // Assert
+            result.Status.Should().Be(ResultStatus.Error);
+            result.ErrorMessage.Should().Be("Kaboom");
+        }
+
+        [Fact]
+        public async Task Returns_Non_Successful_Result_From_Additional_Parameter_Creation()
+        {
+            // Arrange
+            var codeGenerationProvider = Fixture.Freeze<ICodeGenerationProvider>();
+            var generationEnvironment = Fixture.Freeze<IGenerationEnvironment>();
+            var codeGenerationSettings = Fixture.Freeze<ICodeGenerationSettings>();
+            var templateEngine = Fixture.Freeze<ITemplateEngine>();
+            codeGenerationProvider.Encoding.Returns(Encoding.Latin1);
+            codeGenerationProvider.Path.Returns(TestData.BasePath);
+            codeGenerationProvider.GetGeneratorType().Returns(GetType());
+            codeGenerationProvider.CreateModel().Returns(Task.FromResult(Result.Continue<object?>()));
+            codeGenerationProvider.CreateAdditionalParameters().Returns(Task.FromResult(Result.Error<object?>("Kaboom")));
+            var sut = CreateSut();
+
+            // Act
+            var result = await sut.Generate(codeGenerationProvider, generationEnvironment, codeGenerationSettings);
+
+            // Assert
+            result.Status.Should().Be(ResultStatus.Error);
+            result.ErrorMessage.Should().Be("Kaboom");
         }
 
         [Fact]

--- a/src/Core.CodeGeneration.Tests/CodeGenerationEngineTests.cs
+++ b/src/Core.CodeGeneration.Tests/CodeGenerationEngineTests.cs
@@ -64,8 +64,8 @@ public class CodeGenerationEngineTests : TestBase<CodeGenerationEngine>
             codeGenerationProvider.Encoding.Returns(Encoding.Latin1);
             codeGenerationProvider.Path.Returns(TestData.BasePath);
             codeGenerationProvider.GetGeneratorType().Returns(GetType());
-            codeGenerationProvider.CreateModel().Returns(Task.FromResult(Result.Continue<object?>()));
-            codeGenerationProvider.CreateAdditionalParameters().Returns(Task.FromResult(Result.Continue<object?>()));
+            codeGenerationProvider.CreateModel(Arg.Any<CancellationToken>()).Returns(Task.FromResult(Result.Continue<object?>()));
+            codeGenerationProvider.CreateAdditionalParameters(Arg.Any<CancellationToken>()).Returns(Task.FromResult(Result.Continue<object?>()));
             codeGenerationSettings.DryRun.Returns(false);
             codeGenerationSettings.BasePath.Returns(TestData.BasePath);
             codeGenerationSettings.DefaultFilename.Returns("Filename.txt");
@@ -92,8 +92,8 @@ public class CodeGenerationEngineTests : TestBase<CodeGenerationEngine>
             codeGenerationProvider.Encoding.Returns(Encoding.Latin1);
             codeGenerationProvider.Path.Returns(TestData.BasePath);
             codeGenerationProvider.GetGeneratorType().Returns(GetType());
-            codeGenerationProvider.CreateModel().Returns(Task.FromResult(Result.Continue<object?>()));
-            codeGenerationProvider.CreateAdditionalParameters().Returns(Task.FromResult(Result.Continue<object?>()));
+            codeGenerationProvider.CreateModel(Arg.Any<CancellationToken>()).Returns(Task.FromResult(Result.Continue<object?>()));
+            codeGenerationProvider.CreateAdditionalParameters(Arg.Any<CancellationToken>()).Returns(Task.FromResult(Result.Continue<object?>()));
             codeGenerationSettings.DryRun.Returns(true);
             codeGenerationSettings.DefaultFilename.Returns("Filename.txt");
             templateEngine.Render(Arg.Any<IRenderTemplateRequest>(), Arg.Any<CancellationToken>()).Returns(Result.Success());
@@ -192,8 +192,8 @@ public class CodeGenerationEngineTests : TestBase<CodeGenerationEngine>
             codeGenerationProvider.Encoding.Returns(Encoding.Latin1);
             codeGenerationProvider.Path.Returns(TestData.BasePath);
             codeGenerationProvider.GetGeneratorType().Returns(GetType());
-            codeGenerationProvider.CreateModel().Returns(Task.FromResult(Result.Error<object?>("Kaboom")));
-            codeGenerationProvider.CreateAdditionalParameters().Returns(Task.FromResult(Result.Continue<object?>()));
+            codeGenerationProvider.CreateModel(Arg.Any<CancellationToken>()).Returns(Task.FromResult(Result.Error<object?>("Kaboom")));
+            codeGenerationProvider.CreateAdditionalParameters(Arg.Any<CancellationToken>()).Returns(Task.FromResult(Result.Continue<object?>()));
             templateProvider.StartSession(Arg.Any<CancellationToken>()).Returns(Result.Continue());
             var sut = CreateSut();
 
@@ -216,8 +216,8 @@ public class CodeGenerationEngineTests : TestBase<CodeGenerationEngine>
             codeGenerationProvider.Encoding.Returns(Encoding.Latin1);
             codeGenerationProvider.Path.Returns(TestData.BasePath);
             codeGenerationProvider.GetGeneratorType().Returns(GetType());
-            codeGenerationProvider.CreateModel().Returns(Task.FromResult(Result.Continue<object?>()));
-            codeGenerationProvider.CreateAdditionalParameters().Returns(Task.FromResult(Result.Error<object?>("Kaboom")));
+            codeGenerationProvider.CreateModel(Arg.Any<CancellationToken>()).Returns(Task.FromResult(Result.Continue<object?>()));
+            codeGenerationProvider.CreateAdditionalParameters(Arg.Any<CancellationToken>()).Returns(Task.FromResult(Result.Error<object?>("Kaboom")));
             templateProvider.StartSession(Arg.Any<CancellationToken>()).Returns(Result.Continue());
             var sut = CreateSut();
 
@@ -241,8 +241,8 @@ public class CodeGenerationEngineTests : TestBase<CodeGenerationEngine>
             codeGenerationProvider.Encoding.Returns(Encoding.Latin1);
             codeGenerationProvider.Path.Returns(TestData.BasePath);
             codeGenerationProvider.GetGeneratorType().Returns(GetType());
-            codeGenerationProvider.CreateModel().Returns(Task.FromResult(Result.Continue<object?>()));
-            codeGenerationProvider.CreateAdditionalParameters().Returns(Task.FromResult(Result.Continue<object?>()));
+            codeGenerationProvider.CreateModel(Arg.Any<CancellationToken>()).Returns(Task.FromResult(Result.Continue<object?>()));
+            codeGenerationProvider.CreateAdditionalParameters(Arg.Any<CancellationToken>()).Returns(Task.FromResult(Result.Continue<object?>()));
             codeGenerationSettings.DryRun.Returns(true);
             codeGenerationSettings.DefaultFilename.Returns("Filename.txt");
             templateEngine.Render(Arg.Any<IRenderTemplateRequest>(), Arg.Any<CancellationToken>()).Returns(Result.Success());
@@ -307,9 +307,9 @@ public class CodeGenerationEngineTests : TestBase<CodeGenerationEngine>
             public string LastGeneratedFilesFilename => string.Empty;
             public Encoding Encoding => Encoding.UTF8;
 
-            public Task<Result<object?>> CreateAdditionalParameters() => Task.FromResult(Result.Success<object?>(default));
+            public Task<Result<object?>> CreateAdditionalParameters(CancellationToken cancellationToken) => Task.FromResult(Result.Success<object?>(default));
             public Type GetGeneratorType() => typeof(object);
-            public Task<Result<object?>> CreateModel() => Task.FromResult(Result.Success<object?>(default));
+            public Task<Result<object?>> CreateModel(CancellationToken cancellationToken) => Task.FromResult(Result.Success<object?>(default));
 
             private readonly Action<ITemplateComponentRegistry> _action;
             private readonly ResultStatus _status;

--- a/src/Core.CodeGeneration.Tests/CodeGenerationEngineTests.cs
+++ b/src/Core.CodeGeneration.Tests/CodeGenerationEngineTests.cs
@@ -153,7 +153,7 @@ public class CodeGenerationEngineTests : TestBase<CodeGenerationEngine>
 
             // Assert
             result.Status.Should().Be(ResultStatus.Error);
-            counter.Should().Be(1); // start session fails, so the callback of the mock is not reached
+            counter.Should().Be(0); // start session fails, so the callback of the mock is not reached
         }
 
         [Fact]

--- a/src/Core.CodeGeneration.Tests/CodeGenerationEngineTests.cs
+++ b/src/Core.CodeGeneration.Tests/CodeGenerationEngineTests.cs
@@ -153,7 +153,7 @@ public class CodeGenerationEngineTests : TestBase<CodeGenerationEngine>
 
             // Assert
             result.Status.Should().Be(ResultStatus.Error);
-            counter.Should().Be(0); // start session fails, so the callback of the mock is not reached
+            counter.Should().Be(1); // start session fails, so the callback of the mock is not reached
         }
 
         [Fact]
@@ -193,6 +193,7 @@ public class CodeGenerationEngineTests : TestBase<CodeGenerationEngine>
             codeGenerationProvider.Path.Returns(TestData.BasePath);
             codeGenerationProvider.GetGeneratorType().Returns(GetType());
             codeGenerationProvider.CreateModel().Returns(Task.FromResult(Result.Error<object?>("Kaboom")));
+            codeGenerationProvider.CreateAdditionalParameters().Returns(Task.FromResult(Result.Continue<object?>()));
             templateProvider.StartSession(Arg.Any<CancellationToken>()).Returns(Result.Continue());
             var sut = CreateSut();
 

--- a/src/Core.CodeGeneration.Tests/CodeGenerationEngineTests.cs
+++ b/src/Core.CodeGeneration.Tests/CodeGenerationEngineTests.cs
@@ -63,7 +63,8 @@ public class CodeGenerationEngineTests : TestBase<CodeGenerationEngine>
             codeGenerationProvider.Encoding.Returns(Encoding.Latin1);
             codeGenerationProvider.Path.Returns(TestData.BasePath);
             codeGenerationProvider.GetGeneratorType().Returns(GetType());
-            codeGenerationSettings.DryRun.Returns(false);
+            codeGenerationProvider.CreateModel().Returns(Task.FromResult(Result.Continue<object?>()));
+            codeGenerationProvider.CreateAdditionalParameters().Returns(Task.FromResult(Result.Continue<object?>())); codeGenerationSettings.DryRun.Returns(false);
             codeGenerationSettings.BasePath.Returns(TestData.BasePath);
             codeGenerationSettings.DefaultFilename.Returns("Filename.txt");
             templateEngine.Render(Arg.Any<IRenderTemplateRequest>(), Arg.Any<CancellationToken>()).Returns(Result.Success());
@@ -87,7 +88,8 @@ public class CodeGenerationEngineTests : TestBase<CodeGenerationEngine>
             codeGenerationProvider.Encoding.Returns(Encoding.Latin1);
             codeGenerationProvider.Path.Returns(TestData.BasePath);
             codeGenerationProvider.GetGeneratorType().Returns(GetType());
-            codeGenerationSettings.DryRun.Returns(true);
+            codeGenerationProvider.CreateModel().Returns(Task.FromResult(Result.Continue<object?>()));
+            codeGenerationProvider.CreateAdditionalParameters().Returns(Task.FromResult(Result.Continue<object?>())); codeGenerationSettings.DryRun.Returns(true);
             codeGenerationSettings.DefaultFilename.Returns("Filename.txt");
             templateEngine.Render(Arg.Any<IRenderTemplateRequest>(), Arg.Any<CancellationToken>()).Returns(Result.Success());
             var sut = CreateSut();
@@ -158,6 +160,8 @@ public class CodeGenerationEngineTests : TestBase<CodeGenerationEngine>
             codeGenerationProvider.Encoding.Returns(Encoding.Latin1);
             codeGenerationProvider.Path.Returns(TestData.BasePath);
             codeGenerationProvider.GetGeneratorType().Returns(GetType());
+            codeGenerationProvider.CreateModel().Returns(Task.FromResult(Result.Continue<object?>()));
+            codeGenerationProvider.CreateAdditionalParameters().Returns(Task.FromResult(Result.Continue<object?>()));
             codeGenerationSettings.DryRun.Returns(true);
             codeGenerationSettings.DefaultFilename.Returns("Filename.txt");
             var sut = CreateSut();
@@ -217,9 +221,9 @@ public class CodeGenerationEngineTests : TestBase<CodeGenerationEngine>
             public string LastGeneratedFilesFilename => string.Empty;
             public Encoding Encoding => Encoding.UTF8;
 
-            public Task<object?> CreateAdditionalParameters() => Task.FromResult(default(object?));
+            public Task<Result<object?>> CreateAdditionalParameters() => Task.FromResult(Result.Success<object?>(default));
             public Type GetGeneratorType() => typeof(object);
-            public Task<object?> CreateModel() => Task.FromResult(default(object?));
+            public Task<Result<object?>> CreateModel() => Task.FromResult(Result.Success<object?>(default));
 
             private readonly Action<ITemplateComponentRegistry> _action;
             private readonly ResultStatus _status;

--- a/src/Core.CodeGeneration.Tests/IntegrationTests.cs
+++ b/src/Core.CodeGeneration.Tests/IntegrationTests.cs
@@ -40,9 +40,9 @@ public class IntegrationTests : TestBase
         public string LastGeneratedFilesFilename => "*.generated.txt";
         public Encoding Encoding => Encoding.UTF8;
 
-        public Task<Result<object?>> CreateAdditionalParameters() => Task.FromResult(Result.Success<object?>(default));
+        public Task<Result<object?>> CreateAdditionalParameters(CancellationToken cancellationToken) => Task.FromResult(Result.Success<object?>(default));
         public Type GetGeneratorType() => typeof(IntegrationTemplate);
-        public Task<Result<object?>> CreateModel() => Task.FromResult(Result.Success<object?>("Hello world!"));
+        public Task<Result<object?>> CreateModel(CancellationToken cancellationToken) => Task.FromResult(Result.Success<object?>("Hello world!"));
     }
 
     public sealed class IntegrationTemplate : IMultipleContentBuilderTemplate, IModelContainer<string>

--- a/src/Core.CodeGeneration.Tests/IntegrationTests.cs
+++ b/src/Core.CodeGeneration.Tests/IntegrationTests.cs
@@ -40,9 +40,9 @@ public class IntegrationTests : TestBase
         public string LastGeneratedFilesFilename => "*.generated.txt";
         public Encoding Encoding => Encoding.UTF8;
 
-        public Task<object?> CreateAdditionalParameters() => Task.FromResult(default(object?));
+        public Task<Result<object?>> CreateAdditionalParameters() => Task.FromResult(Result.Success<object?>(default));
         public Type GetGeneratorType() => typeof(IntegrationTemplate);
-        public Task<object?> CreateModel() => Task.FromResult<object?>("Hello world!");
+        public Task<Result<object?>> CreateModel() => Task.FromResult(Result.Success<object?>("Hello world!"));
     }
 
     public sealed class IntegrationTemplate : IMultipleContentBuilderTemplate, IModelContainer<string>

--- a/src/Core.CodeGeneration.Tests/TestData.cs
+++ b/src/Core.CodeGeneration.Tests/TestData.cs
@@ -25,11 +25,11 @@ public sealed class MyGeneratorProvider : ICodeGenerationProvider
 
     public Encoding Encoding => Encoding.UTF8;
 
-    public Task<object?> CreateAdditionalParameters() => Task.FromResult(default(object?));
+    public Task<Result<object?>> CreateAdditionalParameters() => Task.FromResult(Result.Success<object?>(default));
 
     public Type GetGeneratorType() => typeof(MyGenerator);
 
-    public Task<object?> CreateModel() => Task.FromResult(default(object?));
+    public Task<Result<object?>> CreateModel() => Task.FromResult(Result.Success<object?>(default));
 }
 
 public sealed class MyGenerator

--- a/src/Core.CodeGeneration.Tests/TestData.cs
+++ b/src/Core.CodeGeneration.Tests/TestData.cs
@@ -25,11 +25,11 @@ public sealed class MyGeneratorProvider : ICodeGenerationProvider
 
     public Encoding Encoding => Encoding.UTF8;
 
-    public Task<Result<object?>> CreateAdditionalParameters() => Task.FromResult(Result.Success<object?>(default));
+    public Task<Result<object?>> CreateAdditionalParameters(CancellationToken cancellationToken) => Task.FromResult(Result.Success<object?>(default));
 
     public Type GetGeneratorType() => typeof(MyGenerator);
 
-    public Task<Result<object?>> CreateModel() => Task.FromResult(Result.Success<object?>(default));
+    public Task<Result<object?>> CreateModel(CancellationToken cancellationToken) => Task.FromResult(Result.Success<object?>(default));
 }
 
 public sealed class MyGenerator

--- a/src/Core.CodeGeneration/CodeGenerationEngine.cs
+++ b/src/Core.CodeGeneration/CodeGenerationEngine.cs
@@ -24,13 +24,13 @@ public sealed class CodeGenerationEngine : ICodeGenerationEngine
         Guard.IsNotNull(settings);
 
         var resultSetBuilder = new NamedResultSetBuilder();
-        resultSetBuilder.Add(nameof(ITemplateProvider.StartSession), _templateProvider.StartSession(cancellationToken));
+        resultSetBuilder.Add(nameof(ITemplateProvider.StartSession), () => _templateProvider.StartSession(cancellationToken));
         if (codeGenerationProvider is ITemplateComponentRegistryPlugin plugin)
         {
-            resultSetBuilder.Add(nameof(ITemplateComponentRegistryPlugin.Initialize), plugin.Initialize(_templateProvider, cancellationToken));
+            resultSetBuilder.Add(nameof(ITemplateComponentRegistryPlugin.Initialize), () => plugin.Initialize(_templateProvider, cancellationToken));
         }
-        resultSetBuilder.Add(nameof(ICodeGenerationProvider.CreateModel), codeGenerationProvider.CreateModel());
-        resultSetBuilder.Add(nameof(ICodeGenerationProvider.CreateAdditionalParameters), codeGenerationProvider.CreateAdditionalParameters());
+        resultSetBuilder.Add(nameof(ICodeGenerationProvider.CreateModel), codeGenerationProvider.CreateModel);
+        resultSetBuilder.Add(nameof(ICodeGenerationProvider.CreateAdditionalParameters), codeGenerationProvider.CreateAdditionalParameters);
 
         var results = await resultSetBuilder.Build().ConfigureAwait(false);
 
@@ -48,9 +48,9 @@ public sealed class CodeGenerationEngine : ICodeGenerationEngine
             new RenderTemplateRequest
             (
                 identifier: new TemplateTypeIdentifier(codeGenerationProvider.GetGeneratorType(), _templateFactory),
-                model: modelResult.Value,
+                model: modelResult.GetValue(),
                 generationEnvironment: generationEnvironment,
-                additionalParameters: additionalParametersResult.Value,
+                additionalParameters: additionalParametersResult.GetValue(),
                 defaultFilename: settings.DefaultFilename,
                 context: null
             ), cancellationToken).ConfigureAwait(false);

--- a/src/Core.CodeGeneration/CodeGenerationEngine.cs
+++ b/src/Core.CodeGeneration/CodeGenerationEngine.cs
@@ -23,9 +23,13 @@ public sealed class CodeGenerationEngine : ICodeGenerationEngine
         Guard.IsNotNull(generationEnvironment);
         Guard.IsNotNull(settings);
 
-        await _templateProvider.StartSession(cancellationToken).ConfigureAwait(false);
-
         Result result;
+
+        result = await _templateProvider.StartSession(cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccessful())
+        {
+            return result;
+        }
 
         if (codeGenerationProvider is ITemplateComponentRegistryPlugin plugin)
         {

--- a/src/Core.CodeGeneration/CodeGenerationEngine.cs
+++ b/src/Core.CodeGeneration/CodeGenerationEngine.cs
@@ -29,8 +29,8 @@ public sealed class CodeGenerationEngine : ICodeGenerationEngine
         {
             resultSetBuilder.Add(nameof(ITemplateComponentRegistryPlugin.Initialize), () => plugin.Initialize(_templateProvider, cancellationToken));
         }
-        resultSetBuilder.Add(nameof(ICodeGenerationProvider.CreateModel), codeGenerationProvider.CreateModel);
-        resultSetBuilder.Add(nameof(ICodeGenerationProvider.CreateAdditionalParameters), codeGenerationProvider.CreateAdditionalParameters);
+        resultSetBuilder.Add(nameof(ICodeGenerationProvider.CreateModel), () => codeGenerationProvider.CreateModel(cancellationToken));
+        resultSetBuilder.Add(nameof(ICodeGenerationProvider.CreateAdditionalParameters), () => codeGenerationProvider.CreateAdditionalParameters(cancellationToken));
 
         var results = await resultSetBuilder.Build().ConfigureAwait(false);
 

--- a/src/Core.CodeGeneration/CodeGenerationEngine.cs
+++ b/src/Core.CodeGeneration/CodeGenerationEngine.cs
@@ -36,16 +36,25 @@ public sealed class CodeGenerationEngine : ICodeGenerationEngine
             }
         }
 
-        var model = await codeGenerationProvider.CreateModel().ConfigureAwait(false);
-        var additionalParameters = await codeGenerationProvider.CreateAdditionalParameters().ConfigureAwait(false);
+        var modelResult = await codeGenerationProvider.CreateModel().ConfigureAwait(false);
+        if (!modelResult.IsSuccessful())
+        {
+            return modelResult;
+        }
+
+        var additionalParametersResult = await codeGenerationProvider.CreateAdditionalParameters().ConfigureAwait(false);
+        if (!additionalParametersResult.IsSuccessful())
+        {
+            return additionalParametersResult;
+        }
 
         result = await _templateEngine.Render(
             new RenderTemplateRequest
             (
                 identifier: new TemplateTypeIdentifier(codeGenerationProvider.GetGeneratorType(), _templateFactory),
-                model: model,
+                model: modelResult.Value,
                 generationEnvironment: generationEnvironment,
-                additionalParameters: additionalParameters,
+                additionalParameters: additionalParametersResult.Value,
                 defaultFilename: settings.DefaultFilename,
                 context: null
             ), cancellationToken).ConfigureAwait(false);

--- a/src/Core.CodeGeneration/NamedResult.cs
+++ b/src/Core.CodeGeneration/NamedResult.cs
@@ -1,0 +1,7 @@
+﻿namespace TemplateFramework.Core.CodeGeneration;
+
+internal class NamedResult<T>(string name, T result)
+{
+    public string Name { get; } = name ?? throw new ArgumentNullException(nameof(name));
+    public T Result { get; } = result ?? throw new ArgumentNullException(nameof(result));
+}

--- a/src/Core.CodeGeneration/NamedResult.cs
+++ b/src/Core.CodeGeneration/NamedResult.cs
@@ -2,6 +2,6 @@
 
 internal class NamedResult<T>(string name, T result)
 {
-    public string Name { get; } = name ?? throw new ArgumentNullException(nameof(name));
-    public T Result { get; } = result ?? throw new ArgumentNullException(nameof(result));
+    public string Name { get; } = name;
+    public T Result { get; } = result;
 }

--- a/src/Core.CodeGeneration/NamedResultSetBuilder.cs
+++ b/src/Core.CodeGeneration/NamedResultSetBuilder.cs
@@ -1,0 +1,20 @@
+﻿namespace TemplateFramework.Core.CodeGeneration;
+
+internal class NamedResultSetBuilder
+{
+    private readonly List<NamedResult<Task<Result<object?>>>> _resultset = new();
+
+    public void Add(string name, Task<Result<object?>> value) => _resultset.Add(new(name, value));
+    public void Add(string name, Task<Result> value) => _resultset.Add(new(name, value.ContinueWith(x => Result.FromExistingResult<object?>(x.Result), TaskScheduler.Current)));
+
+    public async Task<NamedResult<Result<object?>>[]> Build()
+    {
+        var results = await _resultset
+            .SelectAsync(async x => new NamedResult<Result<object?>>(x.Name, await x.Result.ConfigureAwait(false)))
+            .ConfigureAwait(false);
+
+        return results
+            .TakeWhileWithFirstNonMatching(x => x.Result.IsSuccessful())
+            .ToArray();
+    }
+}

--- a/src/TemplateProviders.ChildTemplateProvider.Tests/TestData.cs
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/TestData.cs
@@ -417,11 +417,11 @@ public sealed class CsharpClassGeneratorCodeGenerationProvider : ICodeGeneration
     public string LastGeneratedFilesFilename => string.Empty;
     public Encoding Encoding => Encoding.UTF8;
 
-    public Task<object?> CreateAdditionalParameters() => Task.FromResult(default(object));
+    public Task<Result<object?>> CreateAdditionalParameters() => Task.FromResult(Result.Success<object?>(default));
 
     public Type GetGeneratorType() => typeof(TestData.CsharpClassGenerator);
 
-    public Task<object?> CreateModel()
+    public Task<Result<object?>> CreateModel()
     {
         var settings = new TestData.CsharpClassGeneratorSettings
         (
@@ -445,7 +445,7 @@ public sealed class CsharpClassGeneratorCodeGenerationProvider : ICodeGeneration
 
         var viewModel = new TestData.CsharpClassGeneratorViewModel<IEnumerable<TestData.TypeBase>>(model, settings);
 
-        return Task.FromResult<object?>(viewModel);
+        return Task.FromResult(Result.Success<object?>(viewModel));
     }
 
     public Task<Result> Initialize(ITemplateComponentRegistry registry, CancellationToken cancellationToken)

--- a/src/TemplateProviders.ChildTemplateProvider.Tests/TestData.cs
+++ b/src/TemplateProviders.ChildTemplateProvider.Tests/TestData.cs
@@ -417,11 +417,11 @@ public sealed class CsharpClassGeneratorCodeGenerationProvider : ICodeGeneration
     public string LastGeneratedFilesFilename => string.Empty;
     public Encoding Encoding => Encoding.UTF8;
 
-    public Task<Result<object?>> CreateAdditionalParameters() => Task.FromResult(Result.Success<object?>(default));
+    public Task<Result<object?>> CreateAdditionalParameters(CancellationToken cancellationToken) => Task.FromResult(Result.Success<object?>(default));
 
     public Type GetGeneratorType() => typeof(TestData.CsharpClassGenerator);
 
-    public Task<Result<object?>> CreateModel()
+    public Task<Result<object?>> CreateModel(CancellationToken cancellationToken)
     {
         var settings = new TestData.CsharpClassGeneratorSettings
         (

--- a/src/TemplateProviders.StringTemplateProvider/ProviderComponent.cs
+++ b/src/TemplateProviders.StringTemplateProvider/ProviderComponent.cs
@@ -40,11 +40,11 @@ public class ProviderComponent : ITemplateProviderComponent, ISessionAwareCompon
         }
     }
 
-    public Task StartSession(CancellationToken cancellationToken)
+    public Task<Result> StartSession(CancellationToken cancellationToken)
     {
         _componentRegistrationContext.PlaceholderProcessors.Clear();
         _componentRegistrationContext.FunctionResultParsers.Clear();
 
-        return Task.CompletedTask;
+        return Task.FromResult(Result.Success());
     }
 }


### PR DESCRIPTION
Two (small) breaking changes:

- ICodeGenerationProvider now returns Result<object?> instead of object? on CreateModel and CreateAdditionalParameters, so it can return error results without throwing exceptions
- ISessionAwareComponent now returns Result on StartSession method, so it can return error results without throwing exceptions